### PR TITLE
Test description checking on full description instead of letter per letter

### DIFF
--- a/src/test/scala/com/dataintuitive/viash/MainBuildDockerSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainBuildDockerSuite.scala
@@ -60,7 +60,7 @@ class MainBuildDockerSuite extends FunSuite with BeforeAndAfterAll {
     functionality.arguments.foreach(arg => {
       for (opt <- arg.alternatives; value <- opt)
         assert(stdout.contains(value))
-      for (opt <- arg.description; value <- opt)
+      for (opt <- arg.description; value <- opt.split("\\s+"))
         assert(stdout.contains(value))
     })
 

--- a/src/test/scala/com/dataintuitive/viash/MainBuildDockerSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainBuildDockerSuite.scala
@@ -60,8 +60,19 @@ class MainBuildDockerSuite extends FunSuite with BeforeAndAfterAll {
     functionality.arguments.foreach(arg => {
       for (opt <- arg.alternatives; value <- opt)
         assert(stdout.contains(value))
-      for (opt <- arg.description; value <- opt.split("\\s+"))
-        assert(stdout.contains(value))
+      for (description <- arg.description) {
+        val regex = description.split(raw"\s+")
+          .map(word => {
+            // escape words containing regex special characters
+            if (word.matches(""".*[\<\(\[\{\\\^\-\=\$\!\|\]\}\)\?\*\+\.\>].*"""))
+              s"\\Q$word\\E"
+            else
+              word
+          })
+          .mkString(raw"[\r\n]?\s+")
+        assert(regex.r.findFirstIn(stdout).isDefined)
+      }
+
     })
 
   }

--- a/src/test/scala/com/dataintuitive/viash/MainBuildDockerSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainBuildDockerSuite.scala
@@ -57,24 +57,15 @@ class MainBuildDockerSuite extends FunSuite with BeforeAndAfterAll {
         Seq(executable.toString, "--help")
       )
 
+    val stripAll = (s : String) => s.replaceAll(raw"\s+", " ").strip
+
     functionality.arguments.foreach(arg => {
       for (opt <- arg.alternatives; value <- opt)
         assert(stdout.contains(value))
       for (description <- arg.description) {
-        val regex = description.split(raw"\s+")
-          .map(word => {
-            // escape words containing regex special characters
-            if (word.matches(""".*[\<\(\[\{\\\^\-\=\$\!\|\]\}\)\?\*\+\.\>].*"""))
-              s"\\Q$word\\E"
-            else
-              word
-          })
-          .mkString(raw"[\r\n]?\s+")
-        assert(regex.r.findFirstIn(stdout).isDefined)
+        assert(stripAll(stdout).contains(stripAll(description)))
       }
-
     })
-
   }
 
   test("Check whether output is correctly created", DockerTest) {

--- a/src/test/scala/com/dataintuitive/viash/MainBuildNativeSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainBuildNativeSuite.scala
@@ -51,7 +51,7 @@ class MainBuildNativeSuite extends FunSuite with BeforeAndAfterAll {
     functionality.arguments.foreach(arg => {
       for (opt <- arg.alternatives; value <- opt)
         assert(stdout.contains(value))
-      for (opt <- arg.description; value <- opt)
+      for (opt <- arg.description; value <- opt.split("\\s+"))
         assert(stdout.contains(value))
     })
 

--- a/src/test/scala/com/dataintuitive/viash/MainBuildNativeSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainBuildNativeSuite.scala
@@ -48,13 +48,15 @@ class MainBuildNativeSuite extends FunSuite with BeforeAndAfterAll {
         Seq(executable.toString, "--help")
       )
 
+    val stripAll = (s : String) => s.replaceAll(raw"\s+", " ").strip
+
     functionality.arguments.foreach(arg => {
       for (opt <- arg.alternatives; value <- opt)
         assert(stdout.contains(value))
-      for (opt <- arg.description; value <- opt.split("\\s+"))
-        assert(stdout.contains(value))
+      for (description <- arg.description) {
+        assert(stripAll(stdout).contains(stripAll(description)))
+      }
     })
-
   }
 
   test("Check whether output is correctly created") {

--- a/src/test/scala/com/dataintuitive/viash/MainNSBuildNativeSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainNSBuildNativeSuite.scala
@@ -70,7 +70,7 @@ class MainNSBuildNativeSuite extends FunSuite with BeforeAndAfterAll{
       functionality.arguments.foreach(arg => {
         for (opt <- arg.alternatives; value <- opt)
           assert(stdout.contains(value))
-        for (opt <- arg.description; value <- opt)
+        for (opt <- arg.description; value <- opt.split("\\s+"))
           assert(stdout.contains(value))
       })
     }

--- a/src/test/scala/com/dataintuitive/viash/MainNSBuildNativeSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainNSBuildNativeSuite.scala
@@ -67,11 +67,14 @@ class MainNSBuildNativeSuite extends FunSuite with BeforeAndAfterAll{
           Seq(componentExecutableFile(component).toString, "--help")
         )
 
+      val stripAll = (s: String) => s.replaceAll(raw"\s+", " ").strip
+
       functionality.arguments.foreach(arg => {
         for (opt <- arg.alternatives; value <- opt)
           assert(stdout.contains(value))
-        for (opt <- arg.description; value <- opt.split("\\s+"))
-          assert(stdout.contains(value))
+        for (description <- arg.description) {
+          assert(stripAll(stdout).contains(stripAll(description)))
+        }
       })
     }
   }


### PR DESCRIPTION
Fully strip stdout and description texts to check the full description can be found in stdout instead of word per word

Previously this couldn't be done because of indenting changes, but by fully stripping we can do the check