### PR TITLE
No longer automatically add resources dir to $PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Viash 0.5.5
 
+## BREAKING CHANGES
+
+* `Functionality`: The resources dir no longer automatically added to the PATH variable. 
+  To alter this behaviour, set `.functionality.add_resources_to_path` to `true`.
+
 ## MINOR CHANGES
 
 * Bash Script: only define variables which have values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,20 @@
 
 * Bash Script: only define variables which have values.
 
-* CSharp Test Component: Change Docker image to dataintuitive/dotnet-script to have more control over the lifecycle of versioned tags.
+* CSharp Test Component: Change Docker image to dataintuitive/dotnet-script to have more control over the lifecycle of 
+  versioned tags.
+
+## BUG FIXES
+
+* Viash namespace: Fix incorrect output path when the parent directory of a Viash component is not equal to the value of
+  `.functionality.name`.
 
 # Viash 0.5.4
 
 ## BREAKING CHANGES
 
-* `NextFlowPlatform`: The default caching mechanism is now what NextFlow uses as default. In order to replicate earlier caching, `cache: deep` should be specified in the Viash config file.
+* `NextFlowPlatform`: The default caching mechanism is now what NextFlow uses as default. In order to replicate earlier
+  caching, `cache: deep` should be specified in the Viash config file.
 
 ## NEW FEATURES
 

--- a/src/main/scala/com/dataintuitive/viash/CLIConf.scala
+++ b/src/main/scala/com/dataintuitive/viash/CLIConf.scala
@@ -129,7 +129,7 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) {
        |viash is a spec and a tool for defining execution contexts and converting execution instructions to concrete instantiations.
        |
        |This program comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it under certain conditions. For more information, see our license at the link below.
-       |  https://github.com/data-intuitive/viash/blob/master/LICENSE.md
+       |  https://github.com/viash-io/viash/blob/master/LICENSE.md
        |
        |Usage:
        |  viash run config.vsh.yaml -- [arguments for script]
@@ -141,7 +141,7 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) {
        |  viash config view
        |
        |Check the help of a subcommand for more information, or the API available at:
-       |  https://www.data-intuitive.com/viash_docs
+       |  https://viash.io
        |
        |Arguments:""".stripMargin)
 

--- a/src/main/scala/com/dataintuitive/viash/ViashNamespace.scala
+++ b/src/main/scala/com/dataintuitive/viash/ViashNamespace.scala
@@ -34,18 +34,17 @@ object ViashNamespace {
     val configs2 = if (parallel) configs.par else configs
 
     configs2.foreach { conf =>
-      val in = conf.info.get.parent_path
-      val inTool = in.split("/").lastOption.getOrElse("WRONG")
-      val platType = conf.platform.get.id
+      val funName = conf.functionality.name
+      val platformId = conf.platform.get.id
       val out =
         if (!flatten) {
           conf.functionality.namespace
-            .map( ns => target + s"/$platType/$ns/$inTool").getOrElse(target + s"/$platType/$inTool")
+            .map( ns => target + s"/$platformId/$ns/$funName").getOrElse(target + s"/$platformId/$funName")
         } else {
           target
         }
       val namespaceOrNothing = conf.functionality.namespace.map( s => "(" + s + ")").getOrElse("")
-      println(s"Exporting $in $namespaceOrNothing =$platType=> $out")
+      println(s"Exporting $funName $namespaceOrNothing =$platformId=> $out")
       ViashBuild(
         config = conf,
         output = out,

--- a/src/main/scala/com/dataintuitive/viash/ViashTest.scala
+++ b/src/main/scala/com/dataintuitive/viash/ViashTest.scala
@@ -178,7 +178,9 @@ object ViashTest {
           arguments = Nil,
           dummy_arguments = Some(List(dirArg)),
           resources = Some(List(test)),
-          set_wd_to_resources_dir = Some(true)))
+          set_wd_to_resources_dir = Some(true),
+          add_resources_to_path = true
+        ))
         val testBash = BashScript(
           dest = Some(test.filename),
           text = funOnlyTest.resources.getOrElse(Nil).head.text

--- a/src/main/scala/com/dataintuitive/viash/functionality/Functionality.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/Functionality.scala
@@ -40,7 +40,10 @@ case class Functionality(
   // setting this to true will change the working directory
   // to the resources directory when running the script
   // this is used when running `viash test`.
-  set_wd_to_resources_dir: Option[Boolean] = None
+  set_wd_to_resources_dir: Option[Boolean] = None,
+
+  // whether or not to add the resource dir to the path
+  add_resources_to_path: Boolean = false
 ) {
 
   // check whether there are not multiple positional arguments with multiplicity >1

--- a/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
@@ -93,13 +93,18 @@ object BashWrapper {
     val cdToResources =
       if (functionality.set_wd_to_resources_dir.getOrElse(false)) {
         s"""
-           |cd "$$$var_resources_dir"
-           |PATH="$$$var_resources_dir:\\$$PATH"
-           |""".stripMargin
+          |cd "$$$var_resources_dir"""".stripMargin
       } else {
+        ""
+      }
+
+    // check whether the resources dir needs to be added to the path
+    val resourcesToPath =
+      if (functionality.set_wd_to_resources_dir.getOrElse(false)) {
         s"""
-           |PATH="$$$var_resources_dir:\\$$PATH"
-           |""".stripMargin
+          |PATH="$$$var_resources_dir:\\$$PATH"""".stripMargin
+      } else {
+        ""
       }
 
     // DETERMINE HOW TO RUN THE CODE
@@ -118,7 +123,7 @@ object BashWrapper {
            |trap clean_up EXIT
            |cat > "\\$$tempscript" << 'VIASHMAIN'
            |$escapedCode
-           |VIASHMAIN$cdToResources
+           |VIASHMAIN$cdToResources$resourcesToPath
            |${res.meta.command("\\$tempscript")}
            |""".stripMargin
     }


### PR DESCRIPTION
Changes:
* `Functionality`: The resources dir no longer automatically added to the PATH variable. 
  To alter this behaviour, set `.functionality.add_resources_to_path` to `true`.

@tverbeiren is this ok with you? I set it such that for unit tests, the resources dir _is_ still added to the PATH, but by default this is set to false for other components. Do you expect this change to affect anything in your code?
