### PR TITLE
User friendly missing file messages

### DIFF
--- a/src/main/scala/com/dataintuitive/viash/Main.scala
+++ b/src/main/scala/com/dataintuitive/viash/Main.scala
@@ -24,6 +24,9 @@ import helpers.Scala._
 
 import scala.collection.JavaConverters
 import java.io.File
+import java.io.FileNotFoundException
+import java.nio.file.NoSuchFileException
+import com.dataintuitive.viash.helpers.MissingResourceFileException
 
 object Main {
   private val pkg = getClass.getPackage
@@ -34,6 +37,9 @@ object Main {
     try {
       internalMain(args)
     } catch {
+      case e @ ( _: FileNotFoundException | _: NoSuchFileException | _: MissingResourceFileException ) =>
+        System.err.println(s"viash: ${e.getMessage()}")
+        System.exit(1)
       case e: Exception =>
         System.err.println(
           s"""Unexpected error occurred! If you think this is a bug, please post

--- a/src/main/scala/com/dataintuitive/viash/ViashNamespace.scala
+++ b/src/main/scala/com/dataintuitive/viash/ViashNamespace.scala
@@ -116,20 +116,18 @@ object ViashNamespace {
 
         // run tests
         // TODO: it would actually be great if this component could subscribe to testresults messages
-        var setupRes: Option[TestOutput] = None
-        var testRes = List[TestOutput]()
-        try {
-          val ManyTestOutput(setupRes_, testRes_) = ViashTest(
+
+        val ManyTestOutput(setupRes, testRes) = try {
+          ViashTest(
             config = conf,
             keepFiles = keepFiles,
             quiet = true,
             parentTempPath = Some(parentTempPath)
           )
-          setupRes = setupRes_
-          testRes = testRes_
         } catch {
           case e: MissingResourceFileException => 
-            System.err.printf(s"%sviash ns: %s%s\n",Console.YELLOW, e.getMessage, Console.RESET)
+            System.err.println(s"${Console.YELLOW}viash ns: ${e.getMessage}${Console.RESET}")
+            ManyTestOutput(None, List())
         }
 
         val testResults =

--- a/src/main/scala/com/dataintuitive/viash/ViashTest.scala
+++ b/src/main/scala/com/dataintuitive/viash/ViashTest.scala
@@ -120,7 +120,7 @@ object ViashTest {
     } catch {
       case e: MissingResourceFileException =>
         // add config file name to the exception and throw again
-        if (config.info.isDefined) {
+        if (config.info.isDefined && e.config == "") {
           throw MissingResourceFileException(e.resource, Some(config.info.get.config), cause= e.cause)
         }
         throw e

--- a/src/main/scala/com/dataintuitive/viash/ViashTest.scala
+++ b/src/main/scala/com/dataintuitive/viash/ViashTest.scala
@@ -30,6 +30,7 @@ import functionality.resources.{BashScript, Script}
 import platforms.NativePlatform
 import helpers.IO
 import helpers.Circe.{OneOrMore, One, More}
+import com.dataintuitive.viash.helpers.MissingResourceFileException
 
 object ViashTest {
   case class TestOutput(name: String, exitValue: Int, output: String, logFile: String, duration: Long)
@@ -114,7 +115,16 @@ object ViashTest {
     val buildFun = platform.modifyFunctionality(config)
     val buildDir = dir.resolve("build_executable")
     Files.createDirectories(buildDir)
-    IO.writeResources(buildFun.resources, buildDir)
+    try {
+      IO.writeResources(buildFun.resources, buildDir)
+    } catch {
+      case e: MissingResourceFileException =>
+        // add config file name to the exception and throw again
+        if (config.info.isDefined) {
+          throw MissingResourceFileException(e.resource, Some(config.info.get.config), cause= e.cause)
+        }
+        throw e
+    }
 
     // run command, collect output
     val buildResult =

--- a/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
@@ -91,7 +91,12 @@ trait Resource {
         IO.write(uri.get, path, overwrite, executable = is_executable)
       }
     } catch {
-      case e: NoSuchFileException => throw MissingResourceFileException.apply(path.toString(), None, e)
+      case e: NoSuchFileException => 
+        val configString = parent match {
+          case Some(uri) => Some(uri.toString)
+          case _ => None
+        }
+        throw MissingResourceFileException.apply(path.toString(), configString, e)
     }
   }
 

--- a/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
@@ -19,8 +19,9 @@ package com.dataintuitive.viash.functionality.resources
 
 import java.net.URI
 
-import com.dataintuitive.viash.helpers.IO
+import com.dataintuitive.viash.helpers.{IO, MissingResourceFileException}
 import java.nio.file.{Path, Paths}
+import java.nio.file.NoSuchFileException
 
 trait Resource {
   val `type`: String
@@ -83,10 +84,14 @@ trait Resource {
   }
 
   def write(path: Path, overwrite: Boolean) {
-    if (text.isDefined) {
-      IO.write(text.get, path, overwrite, executable = is_executable)
-    } else {
-      IO.write(uri.get, path, overwrite, executable = is_executable)
+    try {
+      if (text.isDefined) {
+        IO.write(text.get, path, overwrite, executable = is_executable)
+      } else {
+        IO.write(uri.get, path, overwrite, executable = is_executable)
+      }
+    } catch {
+      case e: NoSuchFileException => throw MissingResourceFileException.apply(path.toString(), None, e)
     }
   }
 

--- a/src/main/scala/com/dataintuitive/viash/helpers/MissingResourceFileException.scala
+++ b/src/main/scala/com/dataintuitive/viash/helpers/MissingResourceFileException.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020  Data Intuitive
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.dataintuitive.viash.helpers
+
+case class MissingResourceFileException(
+    val resource: String,
+    val config: String,
+    val message: String,
+    val cause: Throwable)
+    extends Exception(message, cause)
+
+object MissingResourceFileException {
+    def apply(resource: String, config: Option[String], cause: Throwable): MissingResourceFileException = {
+        val message = config match {
+            case None => s"Missing resource $resource"
+            case _ => s"Missing resource $resource as specified in $config.get"
+        }
+        MissingResourceFileException(resource, config.getOrElse(""), message, cause)
+    }
+}

--- a/src/main/scala/com/dataintuitive/viash/helpers/MissingResourceFileException.scala
+++ b/src/main/scala/com/dataintuitive/viash/helpers/MissingResourceFileException.scala
@@ -28,7 +28,7 @@ object MissingResourceFileException {
     def apply(resource: String, config: Option[String], cause: Throwable): MissingResourceFileException = {
         val message = config match {
             case None => s"Missing resource $resource"
-            case _ => s"Missing resource $resource as specified in $config.get"
+            case _ => s"Missing resource $resource as specified in ${config.get}"
         }
         MissingResourceFileException(resource, config.getOrElse(""), message, cause)
     }


### PR DESCRIPTION
Catch FileNotFound and NoSuchFile exceptions
Add MissingResourceFile exception to keep track of resource name & originating config file so we can create a descriptive exception message