### PR TITLE
Config file with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   but instead simply "my_component".
 
 * `NextflowVdsl2Platform`: Set `mode=copy` for `auto.publish` and `auto.transcript`.
+
+## BUG FIXES
+
+* `Main`: Added support spaces in filenames of config files and resources
   
 # Viash 0.5.11
 

--- a/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
@@ -43,8 +43,9 @@ trait Resource {
   def uri: Option[URI] = {
     path match {
       case Some(pat) => {
+        val patEsc = pat.replaceAll(" ", "%20")
         val newPath = parent match {
-          case Some(par) => par.resolve(pat).toString
+          case Some(par) => par.resolve(patEsc).toString
           case _ => pat
         }
         Some(IO.uri(newPath))

--- a/src/main/scala/com/dataintuitive/viash/helpers/IO.scala
+++ b/src/main/scala/com/dataintuitive/viash/helpers/IO.scala
@@ -59,8 +59,7 @@ object IO {
   private val uriRegex = "^[a-zA-Z0-9]*:".r
 
   def uri(path: String): URI = {
-    val newURI = if (uriRegex.findFirstIn(path).isDefined) path else "file://" + new File(path).getAbsolutePath
-    new URI(newURI)
+    if (uriRegex.findFirstIn(path).isDefined) new URI(path) else new File(path).toURI()
   }
 
   def read(uri: URI): String = {

--- a/src/test/resources/testbash/config test.vsh.yaml
+++ b/src/test/resources/testbash/config test.vsh.yaml
@@ -1,0 +1,93 @@
+functionality:
+  name: testbash
+  version: 0.1
+  description: |
+    Prints out the parameter values.
+    Checking what happens with multiline descriptions.
+  authors:
+    - name: Bob Cando
+      roles: [maintainer, author]
+      email: bob@cando.com
+      props: {github: bobcando, orcid: XXXAAABBB}
+  arguments:
+    - name: "input"
+      type: file
+      description: |
+        An input file with positional arguments.
+        More checks for multiline descriptions.
+        Testing some characters that should be escaped: ` $ \
+      direction: input
+      required: true
+      must_exist: true
+      example: input.txt
+    - name: "--real_number"
+      type: double
+      description: A real number with positional arguments.
+      required: true
+    - name: "--whole_number"
+      type: integer
+      description: A whole number with a standard flag.
+      required: true
+    - name: "-s"
+      type: string
+      description: A sentence or word with a short flag.
+      required: true
+    - name: "--truth"
+      type: boolean_true
+      description: A switch flag.
+    - name: "--falsehood"
+      type: boolean_false
+      description: A switch flag which is false when specified.
+    - name: "--reality"
+      type: boolean
+      description: A switch flag without predetermined state.
+    - name: "--output"
+      alternatives: [ "-o" ]
+      type: file
+      description: Write the parameters to a json file.
+      direction: output
+    - name: "--log"
+      type: file
+      description: An optional log file.
+      direction: output
+    - name: "--optional"
+      type: string
+      description: An optional string.
+    - name: "--optional_with_default"
+      type: string
+      default: "The default value."
+    - name: "--multiple"
+      type: string
+      multiple: true
+    - name: "multiple_pos"
+      type: string
+      multiple: true
+  resources:
+    - type: bash_script
+      path: ./code.sh
+    - path: resource1.txt
+    - path: https://raw.githubusercontent.com/scala/scala/fff4ec3539ac58f56fdc8f1382c365f32a9fd25a/NOTICE
+  tests:
+    - type: bash_script
+      path: tests/check_outputs.sh
+    - type: bash_script
+      path: tests/fail.sh
+    - path: resource2.txt
+    - path: ./resource 4.txt
+  info:
+    foo: bar
+    custom_tag: custom_value
+platforms:
+  - type: native
+  - type: docker
+    image: "bash:3.2"
+  - type: docker
+    image: "busybox"
+    id: "busybox"
+  - type: nextflow
+    id: "nextflowlegacy"
+    variant: legacy
+    image: ubuntu
+    publish: true
+    tag: xenial
+  - type: nextflow

--- a/src/test/resources/testbash/resource 4.txt
+++ b/src/test/resources/testbash/resource 4.txt
@@ -1,0 +1,1 @@
+This resource file has a space in the name.

--- a/src/test/scala/com/dataintuitive/viash/MainTestDockerSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainTestDockerSuite.scala
@@ -16,7 +16,7 @@ class MainTestDockerSuite extends FunSuite with BeforeAndAfterAll {
   private val configFailedTestFile = getClass.getResource("/testbash/config_failed_test.vsh.yaml").getPath
   private val configFailedBuildFile = getClass.getResource("/testbash/config_failed_build.vsh.yaml").getPath
   private val configNonexistentTestFile = getClass.getResource("/testbash/config_nonexistent_test.vsh.yaml").getPath
-  private val configWithSpacesFile = getClass.getResource("/testbash/config test.vsh.yaml").getPath
+  private val configWithSpacesFile = getClass.getResource("/testbash/config test.vsh.yaml").getPath.replaceAll("%20", " ")
 
   private val configMissingFunctionalityFile = getClass.getResource("/testbash/invalid_configs/config_missing_functionality.vsh.yaml").getPath
   private val configTextFile = getClass.getResource("/testbash/invalid_configs/config.txt").getPath

--- a/src/test/scala/com/dataintuitive/viash/MainTestDockerSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainTestDockerSuite.scala
@@ -16,6 +16,7 @@ class MainTestDockerSuite extends FunSuite with BeforeAndAfterAll {
   private val configFailedTestFile = getClass.getResource("/testbash/config_failed_test.vsh.yaml").getPath
   private val configFailedBuildFile = getClass.getResource("/testbash/config_failed_build.vsh.yaml").getPath
   private val configNonexistentTestFile = getClass.getResource("/testbash/config_nonexistent_test.vsh.yaml").getPath
+  private val configWithSpacesFile = getClass.getResource("/testbash/config test.vsh.yaml").getPath
 
   private val configMissingFunctionalityFile = getClass.getResource("/testbash/invalid_configs/config_missing_functionality.vsh.yaml").getPath
   private val configTextFile = getClass.getResource("/testbash/invalid_configs/config.txt").getPath
@@ -122,6 +123,20 @@ class MainTestDockerSuite extends FunSuite with BeforeAndAfterAll {
     assert(!testOutput.output.contains("Cleaning up temporary directory"))
 
     checkTempDirAndRemove(testOutput.output, true)
+  }
+
+  test("Check config and resource files with spaces in the filename", DockerTest) {
+    val testText = TestHelper.testMain(
+      "test",
+      "-p", "docker",
+      configWithSpacesFile
+    )
+
+    assert(testText.contains("Running tests in temporary directory: "))
+    assert(testText.contains("SUCCESS! All 2 out of 2 test scripts succeeded!"))
+    assert(testText.contains("Cleaning up temporary directory"))
+
+    checkTempDirAndRemove(testText, false)
   }
   //</editor-fold>
   //<editor-fold desc="Invalid config files">


### PR DESCRIPTION
1. prevent issue with spaces by using built in functionality `new File(path).toURI()` instead of doing it manually with `"file://" + new File(path).getAbsolutePath`
2. manually escape resource paths for `par.resolve(pat).toString`
3. Add test bench for spaces in filenames, tests both config and resource
4. Fix `getClass.getResource` in testbench as it introduces %20 as space in the argument when calling the `viash test` code 

Please review `private val configWithSpacesFile = getClass.getResource("/testbash/config test.vsh.yaml").getPath.replaceAll("%20", " ")` in file `src/test/scala/com/dataintuitive/viash/MainTestDockerSuite.scala` line 19