### PR TITLE
Make components disableable in namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Viash [NEXT VERSION]
+
+## MINOR CHANGES
+
+* `Functionality` and `viash ns`: Added `.enabled` in functionality, set to `true` by default.
+  Filter for disabled components in namespace commands
+
 # Viash 0.5.12
 
 ## MINOR CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## MINOR CHANGES
 
 * `Functionality` and `viash ns`: Added `.enabled` in functionality, set to `true` by default.
-  Filter for disabled components in namespace commands
+  Filter for disabled components in namespace commands.
 
 # Viash 0.5.12
 

--- a/src/main/scala/com/dataintuitive/viash/Main.scala
+++ b/src/main/scala/com/dataintuitive/viash/Main.scala
@@ -187,7 +187,7 @@ object Main {
           }
 
           // if config passes regex checks, return it
-          if (queryTest && nameTest && namespaceTest) {
+          if (queryTest && nameTest && namespaceTest && confTest.functionality.enabled) {
             Some(confTest)
           } else {
             None

--- a/src/main/scala/com/dataintuitive/viash/functionality/Functionality.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/Functionality.scala
@@ -42,7 +42,10 @@ case class Functionality(
   // setting this to true will change the working directory
   // to the resources directory when running the script
   // this is used when running `viash test`.
-  set_wd_to_resources_dir: Boolean = false
+  set_wd_to_resources_dir: Boolean = false,
+
+  // setting this to false with disable this component when using namespaces.
+  enabled: Boolean = true
 ) {
 
   // note that in the Functionality companion object, defaults gets added to inputs and outputs *before* actually 

--- a/src/test/resources/testns/src/ns_disabled/code.py
+++ b/src/test/resources/testns/src/ns_disabled/code.py
@@ -1,0 +1,23 @@
+
+### VIASH START
+par = {
+  'input1': 1,
+  'input2': 2,
+  'output': 'output.txt'
+}
+
+### VIASH END
+
+import logging
+import sys
+
+# This is a fake WIP component where the functionality is not yet implemented and always just returns 38
+# Why 38? Because it's a nice number.
+# The component is disabled in the functionality so it should not appear during building/testing/...
+result = 38
+
+print(result)
+
+if par['output'] is not None:
+	with open(par['output'], 'w') as file:
+		file.write(f"input1: {par['input1']} input2: {par['input2']} result: {result}")

--- a/src/test/resources/testns/src/ns_disabled/config.vsh.yaml
+++ b/src/test/resources/testns/src/ns_disabled/config.vsh.yaml
@@ -1,0 +1,28 @@
+functionality:
+  name: ns_disabled
+  namespace: testns
+  version: 0.1
+  description: |
+    Represents a component that is WIP and thus still left disabled
+  enabled: false
+  arguments:
+    - name: "--input1"
+      type: integer
+      description: Value of the first number
+      required: true
+    - name: "--input2"
+      type: integer
+      description: Value of the second number
+      required: true
+    - name: "--output"
+      type: file
+      description: Write the output to a text file.
+      direction: output
+  resources:
+    - type: python_script
+      path: code.py
+  tests:
+    - type: bash_script
+      path: test.sh
+platforms:
+  - type: native

--- a/src/test/resources/testns/src/ns_disabled/test.sh
+++ b/src/test/resources/testns/src/ns_disabled/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+./ns_add --input1 10 --input2 15 --output output_dis.txt
+
+[[ ! -f output_dis.txt ]] && echo "Output file could not be found!" && exit 1
+grep -q 'input1: 10' output_dis.txt
+grep -q 'input2: 15' output_dis.txt
+grep -q 'result: 38' output_dis.txt
+
+echo ">>> Test finished successfully"
+exit 0


### PR DESCRIPTION
Added `.enabled` in functionality, set to `true` by default.
Filter for disabled components in namespace commands