### PR TITLE
Fix deprecated syntax in sbt

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3,8 +3,8 @@ VERSION = $(shell awk -F'\"' '/version :=/ { print $$2 }' build.sbt)
 
 $(obj): $(shell find src/ -name "*.scala")
 	sbt headerCreate \
-	  'set test in assembly := {}' \
-	  'set assemblyOutputPath in assembly := new File("target/viash.jar")' \
+	  'set assembly / test := {}' \
+	  'set assembly / assemblyOutputPath := new File("target/viash.jar")' \
 	  assembly
 	mkdir -p bin
 	cat src/stub.sh target/viash.jar > $(obj)


### PR DESCRIPTION
Migrated to slash syntax introduced in sbt 1.1.0