### PR TITLE
Check if `bc` available, if available do min/max checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 * `viash config inject`: Fix config inject when `.functionality.inputs` or `.functionality.outputs` is used.
 
+* `BashWrapper`: Don't add `bc` as dependency. Only perform integer/float min/max checks when bc is available, otherwise ignore.
+
 # Viash 0.5.13
 
 ## NEW FUNCTIONALITY

--- a/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
@@ -407,7 +407,7 @@ object BashWrapper {
              |      exit 1
              |    fi
              |  else
-             |    ViashNotice '${param.name}' specifies a minimum value but the value was not verified as \\'bc\\' is not present on the system.
+             |    ViashWarning '${param.name}' specifies a minimum value but the value was not verified as \\'bc\\' is not present on the system.
              |  fi
              |""".stripMargin
         case _ => ""
@@ -420,7 +420,7 @@ object BashWrapper {
              |      exit 1
              |    fi
              |  else
-             |    ViashNotice '${param.name}' specifies a maximum value but the value was not verified as \\'bc\\' is not present on the system.
+             |    ViashWarning '${param.name}' specifies a maximum value but the value was not verified as \\'bc\\' is not present on the system.
              |  fi
              |""".stripMargin
         case _ => ""

--- a/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
@@ -406,6 +406,8 @@ object BashWrapper {
              |      ViashError '${param.name}' has be more than or equal to ${min.get}. Use "--help" to get more information on the parameters.
              |      exit 1
              |    fi
+             |  else
+             |    ViashNotice '${param.name}' specifies a minimum value but the value was not verified as \\'bc\\' is not present on the system.
              |  fi
              |""".stripMargin
         case _ => ""
@@ -417,6 +419,8 @@ object BashWrapper {
              |      ViashError '${param.name}' has to be less than or equal to ${max.get}. Use "--help" to get more information on the parameters.
              |      exit 1
              |    fi
+             |  else
+             |    ViashNotice '${param.name}' specifies a maximum value but the value was not verified as \\'bc\\' is not present on the system.
              |  fi
              |""".stripMargin
         case _ => ""

--- a/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
@@ -401,18 +401,22 @@ object BashWrapper {
                          |""".stripMargin
       val minCheck = min match {
         case _ if min.isDefined =>
-          s"""  if ! [[ `echo $$${param.VIASH_PAR} '>=' ${min.get} | bc` -eq 1 ]]; then
-             |    ViashError '${param.name}' has be more than or equal to ${min.get}. Use "--help" to get more information on the parameters.
-             |    exit 1
+          s"""  if command -v bc &> /dev/null; then
+             |    if ! [[ `echo $$${param.VIASH_PAR} '>=' ${min.get} | bc` -eq 1 ]]; then
+             |      ViashError '${param.name}' has be more than or equal to ${min.get}. Use "--help" to get more information on the parameters.
+             |      exit 1
+             |    fi
              |  fi
              |""".stripMargin
         case _ => ""
       }
       val maxCheck = max match {
         case _ if max.isDefined =>
-          s"""  if ! [[ `echo $$${param.VIASH_PAR} '<=' ${max.get} | bc` -eq 1 ]]; then
-             |    ViashError '${param.name}' has to be less than or equal to ${max.get}. Use "--help" to get more information on the parameters.
-             |    exit 1
+          s"""  if command -v bc &> /dev/null; then
+             |    if ! [[ `echo $$${param.VIASH_PAR} '<=' ${max.get} | bc` -eq 1 ]]; then
+             |      ViashError '${param.name}' has to be less than or equal to ${max.get}. Use "--help" to get more information on the parameters.
+             |      exit 1
+             |    fi
              |  fi
              |""".stripMargin
         case _ => ""


### PR DESCRIPTION
Don't add `bc` as dependency. Only perform integer/float min/max checks when bc is available, otherwise ignore.