### PR TITLE
Restore intended legacy `tests` in test bench and use Console.err ins…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * `NextflowVdsl3Platform`: Fix error when optional, multiple arguments are set to `null`.
 
+* `Testbenches`: Better capture expected error messages while running testbenches again. Code changes right before previous release re-introduced some of the messages.
+
 # Viash 0.5.14
 
 ## NEW FUNCTIONALITY

--- a/src/main/scala/com/dataintuitive/viash/Main.scala
+++ b/src/main/scala/com/dataintuitive/viash/Main.scala
@@ -40,10 +40,10 @@ object Main {
       internalMain(args)
     } catch {
       case e @ ( _: FileNotFoundException | _: NoSuchFileException | _: MissingResourceFileException ) =>
-        System.err.println(s"viash: ${e.getMessage()}")
+        Console.err.println(s"viash: ${e.getMessage()}")
         System.exit(1)
       case e: Exception =>
-        System.err.println(
+        Console.err.println(
           s"""Unexpected error occurred! If you think this is a bug, please post
             |create an issue at https://github.com/viash-io/viash/issues containing
             |a reproducible example and the stack trace below.

--- a/src/main/scala/com/dataintuitive/viash/ViashNamespace.scala
+++ b/src/main/scala/com/dataintuitive/viash/ViashNamespace.scala
@@ -151,7 +151,7 @@ object ViashNamespace {
               )
             } catch {
               case e: MissingResourceFileException => 
-                System.err.println(s"${Console.YELLOW}viash ns: ${e.getMessage}${Console.RESET}")
+                Console.err.println(s"${Console.YELLOW}viash ns: ${e.getMessage}${Console.RESET}")
                 ManyTestOutput(None, List())
             }
 

--- a/src/main/scala/com/dataintuitive/viash/functionality/package.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/package.scala
@@ -59,13 +59,13 @@ package object functionality {
       // provide backwords compability for tests -> test_resources
       val fun3 = (fun2.contains("tests"), fun2.contains("test_resources")) match {
         case (true, true) => 
-          System.err.println("Error: functionality.tests is deprecated. Please use functionality.test_resources instead.")
-          System.err.println("Backwards compability is provided but not in combination with functionality.test_resources.")
+          Console.err.println("Error: functionality.tests is deprecated. Please use functionality.test_resources instead.")
+          Console.err.println("Backwards compability is provided but not in combination with functionality.test_resources.")
           fun2
         case (true, false) =>
           if (noticeFunTestDepr) {
             // todo: solve this in a cleaner way
-            System.err.println("Notice: functionality.tests is deprecated. Please use functionality.test_resources instead.")
+            Console.err.println("Notice: functionality.tests is deprecated. Please use functionality.test_resources instead.")
             noticeFunTestDepr = false
           }
           fun2.add("test_resources", fun2.apply("tests").get).remove("tests")

--- a/src/test/resources/testbash/config_legacy.vsh.yaml
+++ b/src/test/resources/testbash/config_legacy.vsh.yaml
@@ -67,7 +67,8 @@ functionality:
       path: ./code.sh
     - path: resource1.txt
     - path: https://raw.githubusercontent.com/scala/scala/fff4ec3539ac58f56fdc8f1382c365f32a9fd25a/NOTICE
-  test_resources:
+  # use legacy 'tests' instead of 'test_resources'
+  tests:
     - type: bash_script
       path: tests/check_outputs.sh
     - type: bash_script

--- a/src/test/scala/com/dataintuitive/viash/MainTestDockerSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainTestDockerSuite.scala
@@ -140,18 +140,20 @@ class MainTestDockerSuite extends FunSuite with BeforeAndAfterAll {
     checkTempDirAndRemove(testText, false)
   }
 
-    test("Check standard test output with legacy 'tests' definition", DockerTest) {
-    val testText = TestHelper.testMain(
+  test("Check standard test output with legacy 'tests' definition", DockerTest) {
+    val (stdout, stderr) = TestHelper.testMainWithStdErr(
       "test",
       "-p", "docker",
       configLegacyTestFile
     )
 
-    assert(testText.contains("Running tests in temporary directory: "))
-    assert(testText.contains("SUCCESS! All 2 out of 2 test scripts succeeded!"))
-    assert(testText.contains("Cleaning up temporary directory"))
+    assert(stderr.contains("Notice: functionality.tests is deprecated. Please use functionality.test_resources instead."))
 
-    checkTempDirAndRemove(testText, false)
+    assert(stdout.contains("Running tests in temporary directory: "))
+    assert(stdout.contains("SUCCESS! All 2 out of 2 test scripts succeeded!"))
+    assert(stdout.contains("Cleaning up temporary directory"))
+
+    checkTempDirAndRemove(stdout, false)
   }
   //</editor-fold>
   //<editor-fold desc="Invalid config files">


### PR DESCRIPTION
…tead of System.err

Previous commit fixes moved `tests` to `test_resources` but there should be one remaining
Use `System.err` to `Console.err` so we can capture the output stream in the test benches
Add assert while checking the legacy `tests` for the notice message expected on the err stream

Change the `System.err` calls in `Main.scala` to `Console.err` too. This is not needed for the testbenches at the moment but then it's consistent