### PR TITLE
When adding a resource folder, allow a trailing `/` at the end of the…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
 
 * `NextflowVdsl3Platform`: Use `$NXF_TEMP` or `$VIASH_TEMP` as temporary directory if the container engine is not set to `docker`, `podman` or `charlieengine`, else set to `/tmp`.
 
+* `Resources`: When adding a resource folder, allow a trailing `/` at the end of the path.
+  Previously this caused the target folder to be erased and the content of the resource folder to be written directly into the target folder.
+
 # Viash 0.5.14
 
 ## NEW FUNCTIONALITY

--- a/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
@@ -56,6 +56,8 @@ trait Resource {
   }
 
   private val basenameRegex = ".*/".r
+  private val removeTrailingSlashes = "/+$".r
+  
 
   /**
    * Get the path of the resource relative to the resources dir.
@@ -66,7 +68,7 @@ trait Resource {
     if (dest.isDefined) {
       dest.get
     } else {
-      basenameRegex.replaceFirstIn(path.get.stripSuffix("/"), "")
+      basenameRegex.replaceFirstIn( removeTrailingSlashes.replaceFirstIn(path.get, ""), "")
     }
   }
   /**

--- a/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
@@ -66,7 +66,7 @@ trait Resource {
     if (dest.isDefined) {
       dest.get
     } else {
-      basenameRegex.replaceFirstIn(path.get, "")
+      basenameRegex.replaceFirstIn(path.get.stripSuffix("/"), "")
     }
   }
   /**

--- a/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
@@ -68,7 +68,7 @@ trait Resource {
     if (dest.isDefined) {
       dest.get
     } else {
-      getFolderNameRegex.replaceFirstIn(path.get, "$1")
+      getFolderNameRegex.replaceFirstIn(Paths.get(path.get).normalize.toString, "$1")
     }
   }
   /**

--- a/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
@@ -56,7 +56,7 @@ trait Resource {
   }
 
   private val basenameRegex = ".*/".r
-  private val getFolderNameRegex = ".*?([^/]+)/*$".r
+  private val getFolderNameRegex = ".*?([^/]+|/)/*$".r
   
 
   /**
@@ -68,8 +68,7 @@ trait Resource {
     if (dest.isDefined) {
       dest.get
     } else {
-      val getFolderNameRegex(folderName) = path.get
-      folderName
+      getFolderNameRegex.replaceFirstIn(path.get, "$1")
     }
   }
   /**

--- a/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
+++ b/src/main/scala/com/dataintuitive/viash/functionality/resources/Resource.scala
@@ -56,7 +56,7 @@ trait Resource {
   }
 
   private val basenameRegex = ".*/".r
-  private val removeTrailingSlashes = "/+$".r
+  private val getFolderNameRegex = ".*?([^/]+)/*$".r
   
 
   /**
@@ -68,7 +68,8 @@ trait Resource {
     if (dest.isDefined) {
       dest.get
     } else {
-      basenameRegex.replaceFirstIn( removeTrailingSlashes.replaceFirstIn(path.get, ""), "")
+      val getFolderNameRegex(folderName) = path.get
+      folderName
     }
   }
   /**


### PR DESCRIPTION
… path.

  Previously this caused the target folder to be erased and the content of the resource folder to be written directly into the target folder.