### PR TITLE
Check argument is already declared when parsing next argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Viash 0.5.16
+
+## MINOR CHANGES
+
+* `BashWrapper`: Add check to verify a parameter isn't declared twice on the CLI, except in the case `multiple: true` is declared as then it's a valid use case.
+
 # Viash 0.5.15
 
 ## BREAKING CHANGES

--- a/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
@@ -42,7 +42,10 @@ object BashWrapper {
          |  $env="$$$env${multiple_sep.get}"$value
          |fi""".stripMargin.split("\n")
     } else {
-      Array(env + "=" + value)
+      Array(
+        s"""[ -n "$$$env" ] && ViashError Bad arguments for option '$env': \\'$$$env $$2\\' - you should provide exactly one argument for this option. && exit 1""",
+        env + "=" + value
+      )
     }
   }
 

--- a/src/test/scala/com/dataintuitive/viash/MainBuildNativeSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainBuildNativeSuite.scala
@@ -141,6 +141,55 @@ class MainBuildNativeSuite extends FunSuite with BeforeAndAfterAll {
     assert(stdout.contains("INFO: Parsed input arguments"))
   }
 
+  test("Repeated regular arguments are not allowed") {
+    val out = Exec.run2(
+      Seq(
+        executable.toString,
+        executable.toString,
+        "--real_number", "123.456",
+        "--whole_number", "789",
+        "-s", "my$weird#string",
+        "--whole_number", "123",
+      )
+    )
+
+    assert(out.exitValue == 1)
+    assert(out.output.contains("[error] Bad arguments for option VIASH_PAR_WHOLE_NUMBER: '789 123' - you should provide exactly one argument for this option."))
+  }
+
+  test("Repeated flag arguments are not allowed") {
+    val out = Exec.run2(
+      Seq(
+        executable.toString,
+        executable.toString,
+        "--real_number", "123.456",
+        "--whole_number", "789",
+        "-s", "my$weird#string",
+        "--falsehood",
+        "--falsehood"
+      )
+    )
+    assert(out.exitValue == 1)
+    assert(out.output.contains("[error] Bad arguments for option VIASH_PAR_FALSEHOOD: 'false ' - you should provide exactly one argument for this option."))
+  }
+
+  test("Repeated arguments with --multiple defined are allowed") {
+    val out = Exec.run2(
+      Seq(
+        executable.toString,
+        executable.toString,
+        "--real_number", "123.456",
+        "--whole_number", "789",
+        "-s", "my$weird#string",
+        "--multiple", "foo",
+        "--multiple", "bar"
+      )
+    )
+    
+    assert(out.exitValue == 0)
+    assert(out.output.contains("multiple: |foo:bar|"))
+  }
+
   test("when -p is omitted, the system should run as native") {
     val testText = TestHelper.testMain(
       "build",


### PR DESCRIPTION
Throw error when redefining an argument unless --multiple is specified

Fixes #191 