### PR TITLE
Correctly use the argument name when displaying an error message when…

### DIFF
--- a/src/main/scala/com/dataintuitive/viash/platforms/DockerPlatform.scala
+++ b/src/main/scala/com/dataintuitive/viash/platforms/DockerPlatform.scala
@@ -477,7 +477,7 @@ case class DockerPlatform(
                    |  for var in $$${arg.VIASH_PAR}; do
                    |    unset IFS
                    |    $extraMountsVar="$$$extraMountsVar $$(ViashAutodetectMountArg "$$var")"
-                   |    ${BashWrapper.store(viash_temp, "\"$(ViashAutodetectMount \"$var\")\"", Some(arg.multiple_sep)).mkString("\n    ")}
+                   |    ${BashWrapper.store("ViashAutodetectMountArg", viash_temp, "\"$(ViashAutodetectMount \"$var\")\"", Some(arg.multiple_sep)).mkString("\n    ")}
                    |  done
                    |  ${arg.VIASH_PAR}="$$$viash_temp"
                    |fi""".stripMargin)

--- a/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
@@ -43,7 +43,7 @@ object BashWrapper {
   val var_resources_dir = "VIASH_META_RESOURCES_DIR"
   val var_executable = "VIASH_META_EXECUTABLE"
 
-  def store(env: String, value: String, multiple_sep: Option[Char]): Array[String] = {
+  def store(name: String, env: String, value: String, multiple_sep: Option[Char]): Array[String] = {
     if (multiple_sep.isDefined) {
       s"""if [ -z "$$$env" ]; then
          |  $env=$value
@@ -52,7 +52,7 @@ object BashWrapper {
          |fi""".stripMargin.split("\n")
     } else {
       Array(
-        s"""[ -n "$$$env" ] && ViashError Bad arguments for option '$env': \\'$$$env $$2\\' - you should provide exactly one argument for this option. && exit 1""",
+        s"""[ -n "$$$env" ] && ViashError Bad arguments for option \\'$name\\': \\'$$$env\\' \\& \\' $$2\\' - you should provide exactly one argument for this option. && exit 1""",
         env + "=" + value
       )
     }
@@ -68,13 +68,13 @@ object BashWrapper {
     argsConsumed match {
       case num if num > 1 =>
         s"""        $name)
-           |            ${this.store(plainName, store, multiple_sep).mkString("\n            ")}
+           |            ${this.store(name, plainName, store, multiple_sep).mkString("\n            ")}
            |            [ $$# -lt $argsConsumed ] && ViashError Not enough arguments passed to $name. Use "--help" to get more information on the parameters. && exit 1
            |            shift $argsConsumed
            |            ;;""".stripMargin
       case _ =>
         s"""        $name)
-           |            ${this.store(plainName, store, multiple_sep).mkString("\n            ")}
+           |            ${this.store(name, plainName, store, multiple_sep).mkString("\n            ")}
            |            shift $argsConsumed
            |            ;;""".stripMargin
     }
@@ -325,7 +325,7 @@ object BashWrapper {
     val positionalStr = positionals.map { param =>
       if (param.multiple) {
         s"""while [[ $$# -gt 0 ]]; do
-           |  ${store(param.VIASH_PAR, "\"$1\"", Some(param.multiple_sep)).mkString("\n  ")}
+           |  ${store("positionalArg", param.VIASH_PAR, "\"$1\"", Some(param.multiple_sep)).mkString("\n  ")}
            |  shift 1
            |done""".stripMargin
       } else {

--- a/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/com/dataintuitive/viash/wrapper/BashWrapper.scala
@@ -52,7 +52,7 @@ object BashWrapper {
          |fi""".stripMargin.split("\n")
     } else {
       Array(
-        s"""[ -n "$$$env" ] && ViashError Bad arguments for option \\'$name\\': \\'$$$env\\' \\& \\' $$2\\' - you should provide exactly one argument for this option. && exit 1""",
+        s"""[ -n "$$$env" ] && ViashError Bad arguments for option \\'$name\\': \\'$$$env\\' \\& \\'$$2\\' - you should provide exactly one argument for this option. && exit 1""",
         env + "=" + value
       )
     }

--- a/src/test/scala/com/dataintuitive/viash/MainBuildNativeSuite.scala
+++ b/src/test/scala/com/dataintuitive/viash/MainBuildNativeSuite.scala
@@ -154,7 +154,7 @@ class MainBuildNativeSuite extends FunSuite with BeforeAndAfterAll {
     )
 
     assert(out.exitValue == 1)
-    assert(out.output.contains("[error] Bad arguments for option VIASH_PAR_WHOLE_NUMBER: '789 123' - you should provide exactly one argument for this option."))
+    assert(out.output.contains("[error] Bad arguments for option '--whole_number': '789' & '123' - you should provide exactly one argument for this option."))
   }
 
   test("Repeated flag arguments are not allowed") {
@@ -170,7 +170,7 @@ class MainBuildNativeSuite extends FunSuite with BeforeAndAfterAll {
       )
     )
     assert(out.exitValue == 1)
-    assert(out.output.contains("[error] Bad arguments for option VIASH_PAR_FALSEHOOD: 'false ' - you should provide exactly one argument for this option."))
+    assert(out.output.contains("[error] Bad arguments for option '--falsehood': 'false' & '' - you should provide exactly one argument for this option."))
   }
 
   test("Repeated arguments with --multiple defined are allowed") {


### PR DESCRIPTION
… duplicate arguments are detected

fixes #196 