### PR TITLE
Feature/viash ns exec

### DIFF
--- a/src/main/scala/com/dataintuitive/viash/Main.scala
+++ b/src/main/scala/com/dataintuitive/viash/Main.scala
@@ -112,7 +112,12 @@ object Main {
         )
       case List(cli.namespace, cli.namespace.exec) =>
         val configs = readConfigs(cli.namespace.exec, applyPlatform = false)
-        Console.println(s"ns exec: ${cli.namespace.exec.cmd()}")
+        ViashNamespace.exec(
+          configs = configs,
+          command = cli.namespace.exec.cmd(),
+          dryrun = cli.namespace.exec.dryrun()
+        )
+
       case List(cli.config, cli.config.view) =>
         val config = Config.read(
           configPath = cli.config.view.config(),

--- a/src/main/scala/com/dataintuitive/viash/Main.scala
+++ b/src/main/scala/com/dataintuitive/viash/Main.scala
@@ -110,6 +110,9 @@ object Main {
           configs = configs,
           cli.namespace.list.format()
         )
+      case List(cli.namespace, cli.namespace.exec) =>
+        val configs = readConfigs(cli.namespace.exec, applyPlatform = false)
+        Console.println(s"ns exec: ${cli.namespace.exec.cmd()}")
       case List(cli.config, cli.config.view) =>
         val config = Config.read(
           configPath = cli.config.view.config(),

--- a/src/main/scala/com/dataintuitive/viash/ViashNamespace.scala
+++ b/src/main/scala/com/dataintuitive/viash/ViashNamespace.scala
@@ -24,6 +24,7 @@ import helpers.IO
 import io.viash.helpers.MissingResourceFileException
 import io.viash.helpers.BuildStatus._
 import java.nio.file.Path
+import com.dataintuitive.viash.helpers.NsExecData
 
 object ViashNamespace {
   def build(
@@ -233,6 +234,18 @@ object ViashNamespace {
     ViashConfig.viewMany(configs2, format)
 
     printResults(configs.map(_.fold(fa => Success, fb => fb)), false, false)
+  }
+
+  def exec(configs: List[Either[Config, BuildStatus]], command: String, dryrun: Boolean) {
+    Console.println(s"ns exec: $command")
+    Console.println(s"dryrun: $dryrun")
+
+    val goodConfigs = configs.flatMap(_.left.toOption).groupBy(_.info.get.config)
+    for (c <- goodConfigs) {
+        Console.println(s"Found config: ${c._1}")
+        // Just take first config. More can be available but those have different platforms. Platforms are currently ignored.
+        Console.println(NsExecData(c._1, c._2.head))
+    }
   }
 
   def printResults(statuses: Seq[BuildStatus], performedBuild: Boolean, performedTest: Boolean) {

--- a/src/main/scala/com/dataintuitive/viash/cli/CLIConf.scala
+++ b/src/main/scala/com/dataintuitive/viash/cli/CLIConf.scala
@@ -313,9 +313,25 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) {
       )
     }
 
+    val exec = new DocumentedSubcommand("exec") with ViashNs {
+      banner(
+        "viash ns exec",
+        "Execute a command applied to namespace component config files.",
+        "viash ns exec 'cat {} \\;'"
+      )
+
+      val cmd = registerTrailArg[String](
+        name = "cmd",
+        descr = "The command to execute for each viash config file in the namespace.",
+        default = Some("'viash_nxf_params -i {} -o {dir}/params.yaml \\;'"),
+        required = true,
+      )
+    }
+
     addSubcommand(build)
     addSubcommand(test)
     addSubcommand(list)
+    addSubcommand(exec)
     requireSubcommand()
 
     shortSubcommandsHelp(true)

--- a/src/main/scala/com/dataintuitive/viash/cli/CLIConf.scala
+++ b/src/main/scala/com/dataintuitive/viash/cli/CLIConf.scala
@@ -320,6 +320,13 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) {
         "viash ns exec 'cat {} \\;'"
       )
 
+      val dryrun = registerOpt[Boolean] (
+        name = "dry-run",
+        short = Some('d'),
+        default = Some(false),
+        descr = "Perform a dry run."
+      )
+
       val cmd = registerTrailArg[String](
         name = "cmd",
         descr = "The command to execute for each viash config file in the namespace.",

--- a/src/main/scala/com/dataintuitive/viash/helpers/NsExecData.scala
+++ b/src/main/scala/com/dataintuitive/viash/helpers/NsExecData.scala
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020  Data Intuitive
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.dataintuitive.viash.helpers
 
 import io.viash.config.Config
@@ -27,5 +44,18 @@ object NsExecData {
       absoluteMainScript = absoluteMainScript.getOrElse(""),
       functionalityName = config.functionality.name
     )
+  }
+
+  def getField(data: NsExecData, name: String) = {
+    name match {
+      case "" | "path" => Some(data.configFullPath)
+      case "abs-path" => Some(data.absoluteConfigFullPath)
+      case "dir" => Some(data.dir)
+      case "abs-dir" => Some(data.absoluteDir)
+      case "main-script" => Some(data.mainScript)
+      case "abs-main-script" => Some(data.absoluteMainScript)
+      case "functionality-name" => Some(data.functionalityName)
+      case _ => None
+    }
   }
 }

--- a/src/main/scala/com/dataintuitive/viash/helpers/NsExecData.scala
+++ b/src/main/scala/com/dataintuitive/viash/helpers/NsExecData.scala
@@ -1,0 +1,31 @@
+package com.dataintuitive.viash.helpers
+
+import io.viash.config.Config
+import java.nio.file.Paths
+
+final case class NsExecData(
+  configFullPath: String,
+  absoluteConfigFullPath: String,
+  dir: String,
+  absoluteDir: String,
+  mainScript: String,
+  absoluteMainScript: String,
+  functionalityName: String
+)
+
+object NsExecData {
+  def apply(configPath: String, config: Config):NsExecData = {
+    val configPath_ = Paths.get(configPath)
+    val mainScript = config.functionality.mainScript.flatMap(s => s.path)
+    val absoluteMainScript = mainScript.flatMap(m => Some(Paths.get(m).toAbsolutePath.toString))
+    NsExecData(
+      configFullPath = configPath,
+      absoluteConfigFullPath = configPath_.toAbsolutePath.toString,
+      dir = configPath_.getParent.toString,
+      absoluteDir = configPath_.toAbsolutePath.getParent.toString,
+      mainScript = mainScript.getOrElse(""),
+      absoluteMainScript = absoluteMainScript.getOrElse(""),
+      functionalityName = config.functionality.name
+    )
+  }
+}

--- a/src/main/scala/com/dataintuitive/viash/helpers/NsExecData.scala
+++ b/src/main/scala/com/dataintuitive/viash/helpers/NsExecData.scala
@@ -28,14 +28,27 @@ final case class NsExecData(
   mainScript: String,
   absoluteMainScript: String,
   functionalityName: String
-)
+) {
+  def getField(name: String) = {
+    name match {
+      case "" | "path" => Some(this.configFullPath)
+      case "abs-path" => Some(this.absoluteConfigFullPath)
+      case "dir" => Some(this.dir)
+      case "abs-dir" => Some(this.absoluteDir)
+      case "main-script" => Some(this.mainScript)
+      case "abs-main-script" => Some(this.absoluteMainScript)
+      case "functionality-name" => Some(this.functionalityName)
+      case _ => None
+    }
+  }
+}
 
 object NsExecData {
   def apply(configPath: String, config: Config):NsExecData = {
     val configPath_ = Paths.get(configPath)
     val mainScript = config.functionality.mainScript.flatMap(s => s.path)
     val absoluteMainScript = mainScript.flatMap(m => Some(Paths.get(m).toAbsolutePath.toString))
-    NsExecData(
+    apply(
       configFullPath = configPath,
       absoluteConfigFullPath = configPath_.toAbsolutePath.toString,
       dir = configPath_.getParent.toString,
@@ -46,16 +59,15 @@ object NsExecData {
     )
   }
 
-  def getField(data: NsExecData, name: String) = {
-    name match {
-      case "" | "path" => Some(data.configFullPath)
-      case "abs-path" => Some(data.absoluteConfigFullPath)
-      case "dir" => Some(data.dir)
-      case "abs-dir" => Some(data.absoluteDir)
-      case "main-script" => Some(data.mainScript)
-      case "abs-main-script" => Some(data.absoluteMainScript)
-      case "functionality-name" => Some(data.functionalityName)
-      case _ => None
-    }
+  def combine(data: Iterable[NsExecData]) = {
+    apply(
+      configFullPath = data.map(_.configFullPath).mkString(" "),
+      absoluteConfigFullPath = data.map(_.absoluteConfigFullPath).mkString(" "),
+      dir = data.map(_.dir).mkString(" "),
+      absoluteDir = data.map(_.absoluteDir).mkString(" "),
+      mainScript = data.map(_.mainScript).mkString(" "),
+      absoluteMainScript = data.map(_.absoluteMainScript).mkString(" "),
+      functionalityName = data.map(_.functionalityName).mkString(" ")
+    )
   }
 }


### PR DESCRIPTION
Adds a command `viash ns exec` to run commands similar to `find {}`

Supports basic commands with
- {} | {path} => path of Config
- {abs-path}  => absolute path of Config
- {dir} => path to / name of directory
- {abs-dir} => absolute path to directory
- {main-script} => path to mainScript
- {abs-main-script} => absolute path to MainScript
- {functionality-name} => functionality name

However:
- It would be nice to support ConfigMod-like syntax, e.g. {.functionality.name}
- Matching of curly brackets is greedy & too straight forward; when a sub-command as string would be given with curly brackets, this too will be processed, e.g. `viash ns exec 'echo {} "some text {foo}" '`
- functionality was tested on the command line but no real *actual* use cases were tested, so maybe there are conditions where this doesn't work