### PR TITLE
Make meta fields for `memory` and `n_proc` optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,16 @@
 * `BashWrapper`: For int min/max checking: use native bash functionality so there is no dependency to `bc`.
   For double min/max checking: add fallback code to use `awk` in case `bc` is not present on the system (most likely to happen when running tests in a docker container).
 
-# TESTING
+## TESTING
 
 * `ConfigMod`: Added unit tests for config mod functionality (WIP).
 
 * `MainTestDockerSuite`: Derive config alternatives from the base `vsh.yaml` instead of adding the changes in separate files.
   This both reduces file clutter and prevents having to change several files when there are updates in the config format.
+
+## BUG FIXES
+
+* `csharp_script`, `javascript_script`, `python_script`, `r_script`, `scala_script`: Make meta fields for `memory` and `n_proc` optional.
 
 # Viash 0.5.15
 

--- a/src/main/scala/io/viash/functionality/resources/BashScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/BashScript.scala
@@ -47,7 +47,7 @@ case class BashScript(
       val parse = par.par + "=" + Bash.getEscapedArgument(par.VIASH_PAR, "'", """\'""", """\'\"\'\"\'""")
       s"""$$VIASH_DOLLAR$$( if [ ! -z $${${par.VIASH_PAR}+x} ]; then echo "$parse"; fi )"""
     }
-    val metaSet = BashWrapper.metaFields.map{ case (env_name, script_name) =>
+    val metaSet = BashWrapper.metaFields.map{ case BashWrapper.ViashMeta(env_name, script_name, _) =>
       val parse = "meta_" + script_name + "=" + Bash.getEscapedArgument(env_name, "'", """\'""", """\'\"\'\"\'""")
       s"""$$VIASH_DOLLAR$$( if [ ! -z $${$env_name+x} ]; then echo "$parse"; fi )"""
     }

--- a/src/main/scala/io/viash/functionality/resources/CSharpScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/CSharpScript.scala
@@ -92,7 +92,7 @@ case class CSharpScript(
     }
     val metaSet = BashWrapper.metaFields.map{ case BashWrapper.ViashMeta(env_name, script_name, _) =>
       val env_name_escaped = Bash.getEscapedArgument(env_name, quo, """\"""", """\\\"""")
-      s"""$script_name = $$VIASH_DOLLAR$$( if [ ! -z $${$env_name+x} ]; then echo "$env_name_escaped"; else echo "$quo(string) null$quo"; fi )"""
+      s"""$script_name = $$VIASH_DOLLAR$$( if [ ! -z $${$env_name+x} ]; then echo "$env_name_escaped"; else echo "(string) null"; fi )"""
     }
     
     val paramsCode = 

--- a/src/main/scala/io/viash/functionality/resources/CSharpScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/CSharpScript.scala
@@ -40,11 +40,12 @@ case class CSharpScript(
   }
 
   def generateInjectionMods(functionality: Functionality): ScriptInjectionMods = {
+    val quo = "\"'\"'\""
+
     val params = functionality.allArguments.filter(d => d.direction == Input || d.isInstanceOf[FileArgument])
 
     val parSet = params.map { par =>
       // val env_name = par.VIASH_PAR
-      val quo = "\"'\"'\""
       val env_name = Bash.getEscapedArgument(par.VIASH_PAR, quo, """\"""", """\\\"""")
 
       val parse = { par match {
@@ -89,8 +90,9 @@ case class CSharpScript(
 
       s"${par.plainName} = $setter"
     }
-    val metaSet = BashWrapper.metaFields.map{ case (env_name, script_name) =>
-      s"""$script_name = "$$$env_name""""
+    val metaSet = BashWrapper.metaFields.map{ case BashWrapper.ViashMeta(env_name, script_name, _) =>
+      val env_name_escaped = Bash.getEscapedArgument(env_name, quo, """\"""", """\\\"""")
+      s"""$script_name = $$VIASH_DOLLAR$$( if [ ! -z $${$env_name+x} ]; then echo "$env_name_escaped"; else echo "$quo(string) null$quo"; fi )"""
     }
     
     val paramsCode = 

--- a/src/main/scala/io/viash/functionality/resources/JavaScriptScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/JavaScriptScript.scala
@@ -67,8 +67,9 @@ case class JavaScriptScript(
 
       s"""'${par.plainName}': $$VIASH_DOLLAR$$( if [ ! -z $${${par.VIASH_PAR}+x} ]; then echo "$parse"; else echo undefined; fi )"""
     }
-    val metaSet = BashWrapper.metaFields.map{ case (env_name, script_name) =>
-      s"""'$script_name': '$$$env_name'"""
+    val metaSet = BashWrapper.metaFields.map{ case BashWrapper.ViashMeta(env_name, script_name, _) =>
+      val env_name_escaped = Bash.getEscapedArgument(env_name, "'", """\'""", """\\\'""")
+      s"""'$script_name': $$VIASH_DOLLAR$$( if [ ! -z $${$env_name+x} ]; then echo "$env_name_escaped"; else echo undefined; fi )"""
     }
     val paramsCode = s"""let par = {
        |  ${parSet.mkString(",\n  ")}

--- a/src/main/scala/io/viash/functionality/resources/PythonScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/PythonScript.scala
@@ -67,8 +67,9 @@ case class PythonScript(
 
       s"""'${par.plainName}': $$VIASH_DOLLAR$$( if [ ! -z $${${par.VIASH_PAR}+x} ]; then echo "$parse"; else echo None; fi )"""
     }
-    val metaSet = BashWrapper.metaFields.map{ case (env_name, script_name) =>
-      s"""'$script_name': '$$$env_name'"""
+    val metaSet = BashWrapper.metaFields.map{ case BashWrapper.ViashMeta(env_name, script_name, _) =>
+      val env_name_escaped = Bash.getEscapedArgument(env_name, "'", """\'""", """\\\'""")
+      s"""'$script_name': $$VIASH_DOLLAR$$( if [ ! -z $${$env_name+x} ]; then echo "$env_name_escaped"; else echo None; fi )"""
     }
 
     val paramsCode = s"""par = {

--- a/src/main/scala/io/viash/functionality/resources/RScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/RScript.scala
@@ -67,8 +67,9 @@ case class RScript(
 
       s""""${par.plainName}" = $$VIASH_DOLLAR$$( if [ ! -z $${${par.VIASH_PAR}+x} ]; then echo "$parse"; else echo NULL; fi )"""
     }
-    val metaSet = BashWrapper.metaFields.map{ case (env_name, script_name) =>
-      s"""$script_name = "$$$env_name""""
+    val metaSet = BashWrapper.metaFields.map{ case BashWrapper.ViashMeta(env_name, script_name, _) =>
+      val env_name_escaped = Bash.getEscapedArgument(env_name, "'", """\'""", """\\\'""")
+      s""""$script_name" = $$VIASH_DOLLAR$$( if [ ! -z $${$env_name+x} ]; then echo "$env_name_escaped"; else echo NULL; fi )"""
     }
 
     val paramsCode = s"""# treat warnings as errors

--- a/src/main/scala/io/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/io/viash/wrapper/BashWrapper.scala
@@ -23,19 +23,20 @@ import io.viash.functionality.arguments._
 import io.viash.helpers.{Bash, Format, Helper}
 
 object BashWrapper {
-  val metaFields: List[(String, String)] = {
+  case class ViashMeta(envName: String, plainName: String, required: Boolean = true)
+  val metaFields: List[ViashMeta] = {
     List(
-      ("VIASH_META_FUNCTIONALITY_NAME", "functionality_name"),
-      ("VIASH_META_RESOURCES_DIR", "resources_dir"),
-      ("VIASH_META_EXECUTABLE", "executable"),
-      ("VIASH_TEMP", "temp_dir"),
-      ("VIASH_META_N_PROC", "n_proc"),
-      ("VIASH_META_MEMORY_B", "memory_b"),
-      ("VIASH_META_MEMORY_KB", "memory_kb"),
-      ("VIASH_META_MEMORY_MB", "memory_mb"),
-      ("VIASH_META_MEMORY_GB", "memory_gb"),
-      ("VIASH_META_MEMORY_TB", "memory_tb"),
-      ("VIASH_META_MEMORY_PB", "memory_pb")
+      ViashMeta("VIASH_META_FUNCTIONALITY_NAME", "functionality_name"),
+      ViashMeta("VIASH_META_RESOURCES_DIR", "resources_dir"),
+      ViashMeta("VIASH_META_EXECUTABLE", "executable"),
+      ViashMeta("VIASH_TEMP", "temp_dir"),
+      ViashMeta("VIASH_META_N_PROC", "n_proc", required = false),
+      ViashMeta("VIASH_META_MEMORY_B", "memory_b", required = false),
+      ViashMeta("VIASH_META_MEMORY_KB", "memory_kb", required = false),
+      ViashMeta("VIASH_META_MEMORY_MB", "memory_mb", required = false),
+      ViashMeta("VIASH_META_MEMORY_GB", "memory_gb", required = false),
+      ViashMeta("VIASH_META_MEMORY_TB", "memory_tb", required = false),
+      ViashMeta("VIASH_META_MEMORY_PB", "memory_pb", required = false)
 
     )
   }

--- a/src/test/resources/testcsharp/tests/check_outputs.sh
+++ b/src/test/resources/testcsharp/tests/check_outputs.sh
@@ -24,12 +24,24 @@ grep -q 'multiple_pos: |a, b, c, d, e, f|' output.txt
 grep -q 'resources_dir: |..*|' output.txt
 grep -q 'meta_resources_dir: |..*|' output.txt
 grep -q 'meta_functionality_name: |testcsharp|' output.txt
+grep -q 'meta_n_proc: ||' output.txt
+grep -q 'meta_memory_b: ||' output.txt
+grep -q 'meta_memory_kb: ||' output.txt
+grep -q 'meta_memory_mb: ||' output.txt
+grep -q 'meta_memory_gb: ||' output.txt
+grep -q 'meta_memory_tb: ||' output.txt
+grep -q 'meta_memory_pb: ||' output.txt
 
 [[ ! -f log.txt ]] && echo "Log file could not be found!" && exit 1
 grep -q 'Parsed input arguments.' log.txt
 
 echo ">>> Checking whether output is correct with minimal parameters"
-./testcsharp "resource2.txt" --real_number 123.456 --whole_number=789 -s "my\$weird#string\"\"\"'''\`" \
+$meta_executable \
+  "resource2.txt" \
+  --real_number 123.456 \
+  --whole_number=789 -s "my\$weird#string\"\"\"'''\`" \
+  ---n_proc 666 \
+  ---memory 100PB \
   > output2.txt
 
 [[ ! -f output2.txt ]] && echo "Output file could not be found!" && exit 1
@@ -47,5 +59,12 @@ grep -q 'multiple_pos: ||' output2.txt
 grep -q 'resources_dir: |..*|' output2.txt
 grep -q 'meta_resources_dir: |..*|' output.txt
 grep -q 'meta_functionality_name: |testcsharp|' output.txt
+grep -q 'meta_n_proc: |666|' output2.txt
+grep -q 'meta_memory_b: |112589990684262400|' output2.txt
+grep -q 'meta_memory_kb: |109951162777600|' output2.txt
+grep -q 'meta_memory_mb: |107374182400|' output2.txt
+grep -q 'meta_memory_gb: |104857600|' output2.txt
+grep -q 'meta_memory_tb: |102400|' output2.txt
+grep -q 'meta_memory_pb: |100|' output2.txt
 
 echo ">>> Test finished successfully"

--- a/src/test/resources/testjs/tests/check_outputs.sh
+++ b/src/test/resources/testjs/tests/check_outputs.sh
@@ -24,12 +24,24 @@ grep -q 'multiple_pos: |a,b,c,d,e,f|' output.txt
 grep -q 'resources_dir: |..*|' output.txt
 grep -q 'meta_resources_dir: |..*|' output.txt
 grep -q 'meta_functionality_name: |testjs|' output.txt
+grep -q 'meta_n_proc: |undefined|' output.txt
+grep -q 'meta_memory_b: |undefined|' output.txt
+grep -q 'meta_memory_kb: |undefined|' output.txt
+grep -q 'meta_memory_mb: |undefined|' output.txt
+grep -q 'meta_memory_gb: |undefined|' output.txt
+grep -q 'meta_memory_tb: |undefined|' output.txt
+grep -q 'meta_memory_pb: |undefined|' output.txt
 
 [[ ! -f log.txt ]] && echo "Log file could not be found!" && exit 1
 grep -q 'Parsed input arguments.' log.txt
 
 echo ">>> Checking whether output is correct with minimal parameters"
-./testjs "resource2.txt" --real_number 123.456 --whole_number=789 -s "my\$weird#string\"\"\"'''\`@" \
+$meta_executable \
+  "resource2.txt" \
+  --real_number 123.456 \
+  --whole_number=789 -s "my\$weird#string\"\"\"'''\`" \
+  ---n_proc 666 \
+  ---memory 100PB \
   > output2.txt
 
 [[ ! -f output2.txt ]] && echo "Output file could not be found!" && exit 1
@@ -47,5 +59,12 @@ grep -q 'multiple_pos: |undefined|' output2.txt
 grep -q 'resources_dir: |..*|' output2.txt
 grep -q 'meta_resources_dir: |..*|' output2.txt
 grep -q 'meta_functionality_name: |testjs|' output2.txt
+grep -q 'meta_n_proc: |666|' output2.txt
+grep -q 'meta_memory_b: |112589990684262400|' output2.txt
+grep -q 'meta_memory_kb: |109951162777600|' output2.txt
+grep -q 'meta_memory_mb: |107374182400|' output2.txt
+grep -q 'meta_memory_gb: |104857600|' output2.txt
+grep -q 'meta_memory_tb: |102400|' output2.txt
+grep -q 'meta_memory_pb: |100|' output2.txt
 
 echo ">>> Test finished successfully"

--- a/src/test/resources/testjs/tests/check_outputs.sh
+++ b/src/test/resources/testjs/tests/check_outputs.sh
@@ -39,7 +39,8 @@ echo ">>> Checking whether output is correct with minimal parameters"
 $meta_executable \
   "resource2.txt" \
   --real_number 123.456 \
-  --whole_number=789 -s "my\$weird#string\"\"\"'''\`" \
+  --whole_number=789 \
+  -s "my\$weird#string\"\"\"'''\`@" \
   ---n_proc 666 \
   ---memory 100PB \
   > output2.txt

--- a/src/test/resources/testpython/tests/check_outputs.py
+++ b/src/test/resources/testpython/tests/check_outputs.py
@@ -34,6 +34,13 @@ class TestCheckOutputs(unittest.TestCase):
     self.assertRegex(output, 'multiple_pos: \\|\\[\'a\', \'b\', \'c\', \'d\', \'e\', \'f\'\\]\\|')
     self.assertRegex(output, 'meta_resources_dir: \\|..*\\|')
     self.assertRegex(output, 'meta_functionality_name: \\|testpython\\|')
+    self.assertRegex(output, 'meta_n_proc: \\|None\\|')
+    self.assertRegex(output, 'meta_memory_b: \\|None\\|')
+    self.assertRegex(output, 'meta_memory_kb: \\|None\\|')
+    self.assertRegex(output, 'meta_memory_mb: \\|None\\|')
+    self.assertRegex(output, 'meta_memory_gb: \\|None\\|')
+    self.assertRegex(output, 'meta_memory_tb: \\|None\\|')
+    self.assertRegex(output, 'meta_memory_pb: \\|None\\|')
 
     
     self.assertTrue(path.exists("log.txt"))
@@ -46,7 +53,8 @@ class TestCheckOutputs(unittest.TestCase):
   def test_check_output_with_minimal_args(self):
     output = subprocess.check_output(
       ["./testpython", "test", "--real_number", "123.456",
-      "--whole_number", "789", "-s", 'my$weird#string"""\'\'\'`\\@']
+      "--whole_number", "789", "-s", 'my$weird#string"""\'\'\'`\\@',
+      '---n_proc', '666', '---memory', '100PB']
     ).decode("utf-8")
     
     self.assertRegex(output, 'input: \\|test\\|')
@@ -60,6 +68,13 @@ class TestCheckOutputs(unittest.TestCase):
     self.assertRegex(output, 'optional_with_default: \\|The default value.\\|')
     self.assertRegex(output, 'multiple: \\|None\\|')
     self.assertRegex(output, 'multiple_pos: \\|None\\|')
+    self.assertRegex(output, 'meta_n_proc: \\|666\\|')
+    self.assertRegex(output, 'meta_memory_b: \\|112589990684262400\\|')
+    self.assertRegex(output, 'meta_memory_kb: \\|109951162777600\\|')
+    self.assertRegex(output, 'meta_memory_mb: \\|107374182400\\|')
+    self.assertRegex(output, 'meta_memory_gb: \\|104857600\\|')
+    self.assertRegex(output, 'meta_memory_tb: \\|102400\\|')
+    self.assertRegex(output, 'meta_memory_pb: \\|100\\|')
     self.assertRegex(output, 'Parsed input arguments.')
   
   def test_check_error(self):

--- a/src/test/resources/testr/tests/check_outputs.R
+++ b/src/test/resources/testr/tests/check_outputs.R
@@ -30,6 +30,13 @@ test_that("Checking whether output is correct", {
   expect_match(output, 'multiple_pos: \\|c\\("a", "b", "c", "d", "e", "f"\\)\\|')
   expect_match(output, 'meta_resources_dir: \\|..*\\|')
   expect_match(output, 'meta_functionality_name: \\|testr\\|')
+  expect_match(output, 'meta_n_proc: \\|NULL\\|')
+  expect_match(output, 'meta_memory_b: \\|NULL\\|')
+  expect_match(output, 'meta_memory_kb: \\|NULL\\|')
+  expect_match(output, 'meta_memory_mb: \\|NULL\\|')
+  expect_match(output, 'meta_memory_gb: \\|NULL\\|')
+  expect_match(output, 'meta_memory_tb: \\|NULL\\|')
+  expect_match(output, 'meta_memory_pb: \\|NULL\\|')
   
   expect_true(file.exists("log.txt"))
   log <- read_file("log.txt")
@@ -39,7 +46,8 @@ test_that("Checking whether output is correct", {
 
 test_that("Checking whether output is correct with minimal parameters", {
   out <- processx::run("./testr", c(
-    "test", "--real_number", "123.456", "--whole_number=789", "-s", 'my$weird#string"""\'\'\'`@'
+    "test", "--real_number", "123.456", "--whole_number=789", 
+    "-s", 'my$weird#string"""\'\'\'`@', "---n_proc", "666", "---memory", "100PB"
   ))
   
   output <- out$stdout
@@ -54,11 +62,19 @@ test_that("Checking whether output is correct with minimal parameters", {
   expect_match(output, 'multiple_pos: \\|NULL\\|')
   expect_match(output, 'meta_resources_dir: \\|..*\\|')
   expect_match(output, 'meta_functionality_name: \\|testr\\|')
+  expect_match(output, 'meta_n_proc: \\|666\\|')
+  expect_match(output, 'meta_memory_b: \\|112589990684262400\\|')
+  expect_match(output, 'meta_memory_kb: \\|109951162777600\\|')
+  expect_match(output, 'meta_memory_mb: \\|107374182400\\|')
+  expect_match(output, 'meta_memory_gb: \\|104857600\\|')
+  expect_match(output, 'meta_memory_tb: \\|102400\\|')
+  expect_match(output, 'meta_memory_pb: \\|100\\|')
 })
 
 test_that("Checking whether executable fails when wrong parameters are given", {
   out <- processx::run("./testr", error_on_status = FALSE, c(
-    "test", "--real_number", "abc", "--whole_number=abc", "-s", "my weird string", "--derp"
+    "test", "--real_number", "abc", "--whole_number=abc",
+    "-s", "my weird string", "--derp"
   ))
   print(out)
   

--- a/src/test/resources/testscala/tests/check_outputs.sh
+++ b/src/test/resources/testscala/tests/check_outputs.sh
@@ -39,7 +39,7 @@ echo ">>> Checking whether output is correct with minimal parameters"
 $meta_executable \
   "resource2.txt" \
   --real_number 123.456 \
-  --whole_number=789 -s "my\$weird#string\"\"\"'''\`" \
+  --whole_number=789 -s "my\$weird#string\"\"\"'''\`@" \
   ---n_proc 666 \
   ---memory 100PB \
   > output2.txt
@@ -59,12 +59,12 @@ grep -q 'multiple_pos: |List()|' output2.txt
 grep -q 'resources_dir: |..*|' output2.txt
 grep -q 'meta_resources_dir: |..*|' output2.txt
 grep -q 'meta_functionality_name: |testscala|' output2.txt
-grep -q 'meta_n_proc: |666|' output2.txt
-grep -q 'meta_memory_b: |112589990684262400|' output2.txt
-grep -q 'meta_memory_kb: |109951162777600|' output2.txt
-grep -q 'meta_memory_mb: |107374182400|' output2.txt
-grep -q 'meta_memory_gb: |104857600|' output2.txt
-grep -q 'meta_memory_tb: |102400|' output2.txt
-grep -q 'meta_memory_pb: |100|' output2.txt
+grep -q 'meta_n_proc: |Some(666)|' output2.txt
+grep -q 'meta_memory_b: |Some(112589990684262400)|' output2.txt
+grep -q 'meta_memory_kb: |Some(109951162777600)|' output2.txt
+grep -q 'meta_memory_mb: |Some(107374182400)|' output2.txt
+grep -q 'meta_memory_gb: |Some(104857600)|' output2.txt
+grep -q 'meta_memory_tb: |Some(102400)|' output2.txt
+grep -q 'meta_memory_pb: |Some(100)|' output2.txt
 
 echo ">>> Test finished successfully"

--- a/src/test/resources/testscala/tests/check_outputs.sh
+++ b/src/test/resources/testscala/tests/check_outputs.sh
@@ -24,12 +24,24 @@ grep -q 'multiple_pos: |List(a, b, c, d, e, f)|' output.txt
 grep -q 'resources_dir: |..*|' output.txt
 grep -q 'meta_resources_dir: |..*|' output.txt
 grep -q 'meta_functionality_name: |testscala|' output.txt
+grep -q 'meta_n_proc: |None|' output.txt
+grep -q 'meta_memory_b: |None|' output.txt
+grep -q 'meta_memory_kb: |None|' output.txt
+grep -q 'meta_memory_mb: |None|' output.txt
+grep -q 'meta_memory_gb: |None|' output.txt
+grep -q 'meta_memory_tb: |None|' output.txt
+grep -q 'meta_memory_pb: |None|' output.txt
 
 [[ ! -f log.txt ]] && echo "Log file could not be found!" && exit 1
 grep -q 'Parsed input arguments.' log.txt
 
 echo ">>> Checking whether output is correct with minimal parameters"
-./testscala "resource2.txt" --real_number 123.456 --whole_number=789 -s "my\$weird#string\"\"\"'''\`@" \
+$meta_executable \
+  "resource2.txt" \
+  --real_number 123.456 \
+  --whole_number=789 -s "my\$weird#string\"\"\"'''\`" \
+  ---n_proc 666 \
+  ---memory 100PB \
   > output2.txt
 
 [[ ! -f output2.txt ]] && echo "Output file could not be found!" && exit 1
@@ -47,5 +59,12 @@ grep -q 'multiple_pos: |List()|' output2.txt
 grep -q 'resources_dir: |..*|' output2.txt
 grep -q 'meta_resources_dir: |..*|' output2.txt
 grep -q 'meta_functionality_name: |testscala|' output2.txt
+grep -q 'meta_n_proc: |666|' output2.txt
+grep -q 'meta_memory_b: |112589990684262400|' output2.txt
+grep -q 'meta_memory_kb: |109951162777600|' output2.txt
+grep -q 'meta_memory_mb: |107374182400|' output2.txt
+grep -q 'meta_memory_gb: |104857600|' output2.txt
+grep -q 'meta_memory_tb: |102400|' output2.txt
+grep -q 'meta_memory_pb: |100|' output2.txt
 
 echo ">>> Test finished successfully"


### PR DESCRIPTION
`csharp_script`, `javascript_script`, `python_script`, `r_script`, `scala_script`: Make meta fields for `memory` and `n_proc` optional.