### PR TITLE
Remove username & PAT from git remote repository names if present

### DIFF
--- a/src/main/scala/io/viash/helpers/Git.scala
+++ b/src/main/scala/io/viash/helpers/Git.scala
@@ -43,6 +43,7 @@ object Git {
   }
 
   private val remoteRepoRegex = "(.*)\\s(.*)\\s(.*)".r
+  private val removeCredentialsRegex = """^(\w*://)?(\w*:?\w+@)?([^@]*)$""".r
 
   def getRemoteRepo(path: File): Option[String] = {
     Exec.runOpt(
@@ -56,6 +57,7 @@ object Git {
           case _ => None
         }
         .headOption
+        .map(s => removeCredentialsRegex.replaceFirstIn(s, "$1$3"))
     }
   }
 


### PR DESCRIPTION
We don't want this information to be added to a docker container's meta data Remove in git helper class instead of docker platform because we don't want to display in the meta data either