### PR TITLE
Remove username & PAT from git remote repository names if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Viash 0.6.2
+
+## BUG FIXES
+
+* `Git`: Strip credentials from remote repositories when retrieving the path. This could cause usernames and Personal Access Tokens to be stored and/or committed.
+
 # Viash 0.6.1
 
 This release contains mostly minor improvements of functionality released in Viash 0.6.0. Most notably:

--- a/src/main/scala/io/viash/helpers/Git.scala
+++ b/src/main/scala/io/viash/helpers/Git.scala
@@ -43,6 +43,7 @@ object Git {
   }
 
   private val remoteRepoRegex = "(.*)\\s(.*)\\s(.*)".r
+  private val removeCredentialsRegex = """^(\w*://)?(\w*:?\w+@)?([^@]*)$""".r
 
   def getRemoteRepo(path: File): Option[String] = {
     Exec.runOpt(
@@ -56,6 +57,7 @@ object Git {
           case _ => None
         }
         .headOption
+        .map(s => removeCredentialsRegex.replaceFirstIn(s, "$1$3"))
     }
   }
 

--- a/src/main/scala/io/viash/helpers/Git.scala
+++ b/src/main/scala/io/viash/helpers/Git.scala
@@ -43,7 +43,7 @@ object Git {
   }
 
   private val remoteRepoRegex = "(.*)\\s(.*)\\s(.*)".r
-  private val removeCredentialsRegex = """^(\w*://)?(\w*:?\w+@)?([^@]*)$""".r
+  private val removeCredentialsRegex = """^(\w*://|git@)?(\w*:?\w+@)?([^@]*)$""".r
 
   def getRemoteRepo(path: File): Option[String] = {
     Exec.runOpt(

--- a/src/test/scala/io/viash/helpers/GitTest.scala
+++ b/src/test/scala/io/viash/helpers/GitTest.scala
@@ -48,6 +48,44 @@ class GitTest extends FunSuite with BeforeAndAfterAll {
     assert(Git.getTag(tempDir).isEmpty, "Git.getTag")
   }
 
+  test("Check git metadata after git remote add, but remote definition contains credentials username") {
+    val fakeGitRepo = "https://foobar@github.com/viash/meta-test.git"
+    val tempDir = IO.makeTemp("viash_test_meta_3_").toFile
+
+    val gitInitOut = Exec.runCatch(List("git", "init"), cwd = Some(tempDir))
+    assert(gitInitOut.exitValue == 0, s"git init: ${gitInitOut.output}")
+
+    val gitRemoteAddOut = Exec.runCatch(List("git", "remote", "add", "origin", fakeGitRepo), cwd = Some(tempDir))
+    assert(gitRemoteAddOut.exitValue == 0, s"git remote add: ${gitRemoteAddOut.output}")
+
+    val gitInfo = Git.getInfo(tempDir)
+    assert(Git.isGitRepo(tempDir), "Git.isGitRepo")
+    assert(Git.getCommit(tempDir).isEmpty, "Git.getCommit")
+    val lr = Git.getLocalRepo(tempDir)
+    assert(lr.isDefined && lr.get.contains(tempDir.toString), "Git.getLocalRepo")
+    assert(Git.getRemoteRepo(tempDir) == Some("https://github.com/viash/meta-test.git"), "Git.getRemoteRepo")
+    assert(Git.getTag(tempDir).isEmpty, "Git.getTag")
+  }
+
+  test("Check git metadata after git remote add, but remote definition contains credentials username & password/PAT") {
+    val fakeGitRepo = "https://foobar:ghp_SGFoLCB0aGlzIGlzIG5vdCBhIHJlYWwgUEFU@github.com/viash/meta-test.git"
+    val tempDir = IO.makeTemp("viash_test_meta_3_").toFile
+
+    val gitInitOut = Exec.runCatch(List("git", "init"), cwd = Some(tempDir))
+    assert(gitInitOut.exitValue == 0, s"git init: ${gitInitOut.output}")
+
+    val gitRemoteAddOut = Exec.runCatch(List("git", "remote", "add", "origin", fakeGitRepo), cwd = Some(tempDir))
+    assert(gitRemoteAddOut.exitValue == 0, s"git remote add: ${gitRemoteAddOut.output}")
+
+    val gitInfo = Git.getInfo(tempDir)
+    assert(Git.isGitRepo(tempDir), "Git.isGitRepo")
+    assert(Git.getCommit(tempDir).isEmpty, "Git.getCommit")
+    val lr = Git.getLocalRepo(tempDir)
+    assert(lr.isDefined && lr.get.contains(tempDir.toString), "Git.getLocalRepo")
+    assert(Git.getRemoteRepo(tempDir) == Some("https://github.com/viash/meta-test.git"), "Git.getRemoteRepo")
+    assert(Git.getTag(tempDir).isEmpty, "Git.getTag")
+  }
+
   test("Check git metadata after git commit") {
     val tempDir = IO.makeTemp("viash_test_meta_4_").toFile
 


### PR DESCRIPTION
We don't want this information to be added to a docker container's meta data Remove in git helper class instead of docker platform because we don't want to display in the meta data either