### PR TITLE
`DockerPlatform`: Remove duplicate auto-mounts (#257).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Viash 0.6.3
+
+* `DockerPlatform`: Remove duplicate auto-mounts (#257).
+
 # Viash 0.6.2
 
 ## BUG FIXES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Viash 0.6.3
 
+## MINOR CHANGES
+
+* `BashWrapper`: Allow printing the executor command by adding `---verbose ---verbose` to a `viash run`.
+
+## BUG FIXES
+
 * `DockerPlatform`: Remove duplicate auto-mounts (#257).
+
 
 # Viash 0.6.2
 

--- a/src/main/resources/io/viash/helpers/bashutils/ViashAutodetectMount.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashAutodetectMount.sh
@@ -4,7 +4,7 @@
 # $VIASH_EXTRA_MOUNTS : Added another parameter to be passed to docker
 # examples:
 #   ViashAutodetectMount /path/to/bar      # returns '/viash_automount/path/to/bar'
-#   ViashAutodetectMountArg /path/to/bar   # returns '-v /path/to:/viash_automount/path/to'
+#   ViashAutodetectMountArg /path/to/bar   # returns '--volume="/path/to:/viash_automount/path/to"'
 function ViashAutodetectMount {
   abs_path=$(ViashAbsolutePath "$1")
   if [ -d "$abs_path" ]; then
@@ -27,5 +27,5 @@ function ViashAutodetectMountArg {
     base_name=`basename "$abs_path"`
   fi
   mount_target="/viash_automount$mount_source"
-  echo "-v \"$mount_source:$mount_target\""
+  echo "--volume=\"$mount_source:$mount_target\""
 }

--- a/src/main/scala/io/viash/platforms/DockerPlatform.scala
+++ b/src/main/scala/io/viash/platforms/DockerPlatform.scala
@@ -481,8 +481,6 @@ case class DockerPlatform(
     (effectiveID, mods)
   }
 
-  private val extraMountsVar = "VIASH_EXTRA_MOUNTS"
-
   private def processDockerVolumes(functionality: Functionality) = {
     val args = functionality.getArgumentLikes(includeMeta = true)
 
@@ -492,52 +490,63 @@ case class DockerPlatform(
          |${Bash.ViashAutodetectMount}
          |${Bash.ViashExtractFlags}
          |# initialise variables
-         |$extraMountsVar=''""".stripMargin
+         |VIASH_EXTRA_MOUNTS=()""".stripMargin
 
 
     val parsers =
       s"""
          |        ---v|---volume)
-         |            ${Bash.save(extraMountsVar, Seq("-v \"$2\""))}
+         |            VIASH_EXTRA_MOUNTS+=("--volume='$$2'")
          |            shift 2
          |            ;;
          |        ---volume=*)
-         |            ${Bash.save(extraMountsVar, Seq("-v $(ViashRemoveFlags \"$2\")"))}
+         |            VIASH_EXTRA_MOUNTS+=("--volume='$$(ViashRemoveFlags "$$2")'")
          |            shift 1
          |            ;;""".stripMargin
 
-    val extraParams = s" $$$extraMountsVar"
-
     val preRun =
       if (resolve_volume == Automatic) {
-        "\n\n# detect volumes from file arguments" +
-          args.flatMap {
-            case arg: FileArgument if arg.multiple =>
-              // resolve arguments with multiplicity different from singular args
-              val viash_temp = "VIASH_TEST_" + arg.plainName.toUpperCase()
-              Some(
-                s"""
-                   |if [ ! -z "$$${arg.VIASH_PAR}" ]; then
-                   |  IFS="${arg.multiple_sep}"
-                   |  for var in $$${arg.VIASH_PAR}; do
-                   |    unset IFS
-                   |    $extraMountsVar="$$$extraMountsVar $$(ViashAutodetectMountArg "$$var")"
-                   |    ${BashWrapper.store("ViashAutodetectMountArg", viash_temp, "\"$(ViashAutodetectMount \"$var\")\"", Some(arg.multiple_sep)).mkString("\n    ")}
-                   |  done
-                   |  ${arg.VIASH_PAR}="$$$viash_temp"
-                   |fi""".stripMargin)
-            case arg: FileArgument =>
-              Some(
-                s"""
-                   |if [ ! -z "$$${arg.VIASH_PAR}" ]; then
-                   |  $extraMountsVar="$$$extraMountsVar $$(ViashAutodetectMountArg "$$${arg.VIASH_PAR}")"
-                   |  ${arg.VIASH_PAR}=$$(ViashAutodetectMount "$$${arg.VIASH_PAR}")
-                   |fi""".stripMargin)
-            case _ => None
-          }.mkString("")
+        val detectMounts = args.flatMap {
+          case arg: FileArgument if arg.multiple =>
+            // resolve arguments with multiplicity different from singular args
+            val viash_temp = "VIASH_TEST_" + arg.plainName.toUpperCase()
+            Some(
+              s"""
+                  |if [ ! -z "$$${arg.VIASH_PAR}" ]; then
+                  |  IFS="${arg.multiple_sep}"
+                  |  for var in $$${arg.VIASH_PAR}; do
+                  |    unset IFS
+                  |    VIASH_EXTRA_MOUNTS+=( $$(ViashAutodetectMountArg "$$var") )
+                  |    ${BashWrapper.store("ViashAutodetectMountArg", viash_temp, "\"$(ViashAutodetectMount \"$var\")\"", Some(arg.multiple_sep)).mkString("\n    ")}
+                  |  done
+                  |  ${arg.VIASH_PAR}="$$$viash_temp"
+                  |fi""".stripMargin)
+          case arg: FileArgument =>
+            Some(
+              s"""
+                  |if [ ! -z "$$${arg.VIASH_PAR}" ]; then
+                  |  VIASH_EXTRA_MOUNTS+=( $$(ViashAutodetectMountArg "$$${arg.VIASH_PAR}") )
+                  |  ${arg.VIASH_PAR}=$$(ViashAutodetectMount "$$${arg.VIASH_PAR}")
+                  |fi""".stripMargin)
+          case _ => None
+        }
+        
+        if (detectMounts.isEmpty) {
+          ""
+        } else {
+          f"""
+          |
+          |# detect volumes from file arguments${detectMounts.mkString("")}
+          |
+          |# get unique mounts
+          |VIASH_UNIQUE_MOUNTS=($$(for val in "$${VIASH_EXTRA_MOUNTS[@]}"; do echo "$$val"; done | sort -u))
+          |""".stripMargin
+        }
       } else {
         ""
       }
+
+    val extraParams = s" $${VIASH_UNIQUE_MOUNTS[@]}"
 
     BashWrapperMods(
       preParse = preParse,

--- a/src/main/scala/io/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/io/viash/wrapper/BashWrapper.scala
@@ -260,7 +260,7 @@ object BashWrapper {
        |eval set -- $$VIASH_POSITIONAL_ARGS
        |${spaceCode(allMods.postParse)}
        |${spaceCode(allMods.preRun)}
-       |ViashDebug "Running command: $$(${executor.replaceAll("^eval", "echo")})"
+       |ViashDebug "Running command: ${executor.replaceAll("^eval (.*)", "\\$(echo $1)")}"
        |$heredocStart$executor$executionCode$heredocEnd
        |${spaceCode(allMods.postRun)}""".stripMargin
   }

--- a/src/main/scala/io/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/io/viash/wrapper/BashWrapper.scala
@@ -260,6 +260,7 @@ object BashWrapper {
        |eval set -- $$VIASH_POSITIONAL_ARGS
        |${spaceCode(allMods.postParse)}
        |${spaceCode(allMods.preRun)}
+       |ViashDebug "Running command: $$(${executor.replaceAll("^eval", "echo")})"
        |$heredocStart$executor$executionCode$heredocEnd
        |${spaceCode(allMods.postRun)}""".stripMargin
   }


### PR DESCRIPTION
@tverbeiren Could you try running the following?

```bash
make
cat > test.vsh.yaml << HERE
functionality:
  name: issue257
  arguments:
    - name: "--input"
      type: file
      multiple: true
  resources:
    - type: python_script
      path: script.py
      text: print(par)
platforms:
  - type: docker
    image: python:3.10
HERE

viash run test.vsh.yaml -p docker -- --input CHANGELOG.md --input CHANGELOG.md ---verbose ---verbose
```

By adding `---verbose ---verbose`, Viash should print something like:
```
[debug] Running command: docker run --entrypoint=bash -i --rm --volume="..." issue257:latest
```

Which allows to verify whether duplicate volumes are present.

@tverbeiren The most important thing is to know whether the array variables and `sort -n` work as intended on mac os x.