### PR TITLE
Rework `MainBuildAuxiliaryNativeParameterCheck` to create stimulus files and loop over the file from bash instead of looping natively.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * `BashWrapper`: Allow printing the executor command by adding `---verbose ---verbose` to a `viash run`.
 
+* `Testbenches`: Rework `MainBuildAuxiliaryNativeParameterCheck` to create stimulus files and loop over the file from bash instead of looping natively.
+  This prevents creating thousands of new processes which would only test a single parameter.
+  Note this still calls the main script for each stimulus separately, but that was the case anyway, only much much worse.
+
 ## BUG FIXES
 
 * `DockerPlatform`: Remove duplicate auto-mounts (#257).

--- a/src/test/resources/testbash/auxiliary_requirements/parameter_check_loop.vsh.yaml
+++ b/src/test/resources/testbash/auxiliary_requirements/parameter_check_loop.vsh.yaml
@@ -1,0 +1,31 @@
+functionality:
+  name: parameter_check_loop
+  version: 0.1
+  description: |
+    Loops parameter_check using an input file and writing to an output file
+  arguments:
+    - name: --input
+      type: file
+      required: true
+    - name: --output
+      type: file
+      direction: output
+      required: true
+    - name: --exec_path
+      type: string
+      required: true
+    - name: --parameter
+      type: string
+      required: true
+  resources:
+    - type: bash_script
+      text: |
+        while IFS= read -r line
+        do
+          "$par_exec_path" "--$par_parameter" "$line" >& /dev/null
+          echo "$?" >> "$par_output"
+        done < "$par_input"
+        exit 0
+
+platforms:
+  - type: native

--- a/src/test/resources/testbash/auxiliary_requirements/parameter_check_loop.vsh.yaml
+++ b/src/test/resources/testbash/auxiliary_requirements/parameter_check_loop.vsh.yaml
@@ -12,7 +12,7 @@ functionality:
       direction: output
       required: true
     - name: --exec_path
-      type: string
+      type: file
       required: true
     - name: --parameter
       type: string


### PR DESCRIPTION
This prevents creating thousands of new processes which would only test a single parameter. Note this still calls the main script for each stimulus separately, but that was the case anyway, only much much worse.