### PR TITLE
Allow adding structured information to functionality and arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,28 @@
         direction: output
   ```
 
+## MAJOR CHANGES
+
+* `Functionality`: Structured annotation can be added to a functionality and its arguments using the `info` field. Example:
+  ```yaml
+  functionality:
+    name: foo
+    info:
+      site: https://abc.xyz
+      tags: [ one, two, three ]
+    arguments:
+      - name: --foo
+        type: string
+        info:
+          foo: bar
+          a:
+            b:
+              c
+  ```
+
 ## MINOR CHANGES
 
-* `BashWrapper`: Allow printing the executor command by adding `---verbose ---verbose` to a `viash run`.
+* `BashWrapper`: Allow printing the executor command by adding `---verbose ---verbose` to a `viash run` or an executable.
 
 * `Testbenches`: Rework `MainBuildAuxiliaryNativeParameterCheck` to create stimulus files and loop over the file from bash instead of looping natively.
   This prevents creating thousands of new processes which would only test a single parameter.

--- a/src/main/scala/io/viash/functionality/Functionality.scala
+++ b/src/main/scala/io/viash/functionality/Functionality.scala
@@ -17,10 +17,12 @@
 
 package io.viash.functionality
 
+
+import io.circe.Json
+import io.circe.generic.extras._
 import arguments._
 import resources._
 import Status._
-import io.circe.generic.extras._
 import io.viash.schemas._
 import io.viash.wrapper.BashWrapper
 
@@ -238,10 +240,13 @@ case class Functionality(
       "yaml")
   test_resources: List[Resource] = Nil,
 
-  @description("A map for storing custom annotations.")
-  @example("info: {twitter: wizzkid, appId: com.example.myApplication}", "yaml")
+  @description("Structured information. Can be any shape: a string, vector, map or even nested map.")
+  @example(
+    """info:
+      |  twitter: wizzkid
+      |  classes: [ one, two, three ]""".stripMargin, "yaml")
   @since("Viash 0.4.0")
-  info: Map[String, String] = Map.empty[String, String],
+  info: Json = Json.Null,
 
   @description("Allows setting a component to active, deprecated or disabled.")
   @since("Viash 0.6.0")

--- a/src/main/scala/io/viash/functionality/arguments/Argument.scala
+++ b/src/main/scala/io/viash/functionality/arguments/Argument.scala
@@ -17,6 +17,7 @@
 
 package io.viash.functionality.arguments
 
+import io.circe.Json
 import io.viash.helpers.data_structures._
 import io.viash.schemas._
 
@@ -26,6 +27,7 @@ abstract class Argument[Type] {
   val name: String
   val alternatives: OneOrMore[String]
   val description: Option[String]
+  val info: Json
   val example: OneOrMore[Type]
   val default: OneOrMore[Type]
   val required: Boolean
@@ -50,6 +52,7 @@ abstract class Argument[Type] {
     name: String = this.name,
     alternatives: OneOrMore[String] = this.alternatives,
     description: Option[String] = this.description,
+    info: Json = this.info,
     example: OneOrMore[Type] = this.example,
     default: OneOrMore[Type] = this.default,
     required: Boolean = this.required,

--- a/src/main/scala/io/viash/functionality/arguments/BooleanArgument.scala
+++ b/src/main/scala/io/viash/functionality/arguments/BooleanArgument.scala
@@ -17,6 +17,7 @@
 
 package io.viash.functionality.arguments
 
+import io.circe.Json
 import io.viash.helpers.data_structures._
 import io.viash.schemas._
 
@@ -49,6 +50,14 @@ case class BooleanArgument(
 
   @description("A description of the argument. This will be displayed with `--help`.")
   description: Option[String] = None,
+
+  @description("Structured information. Can be any shape: a string, vector, map or even nested map.")
+  @example(
+    """info:
+      |  category: cat1
+      |  labels: [one, two, three]""".stripMargin, "yaml")
+  @since("Viash 0.6.3")
+  info: Json = Json.Null,
   
   @description("An example value for this argument. If no [`default`](#default) property was specified, this will be used for that purpose.")
   @example(
@@ -113,6 +122,7 @@ case class BooleanArgument(
     name: String, 
     alternatives: OneOrMore[String],
     description: Option[String],
+    info: Json,
     example: OneOrMore[Boolean],
     default: OneOrMore[Boolean],
     required: Boolean,
@@ -121,7 +131,7 @@ case class BooleanArgument(
     multiple_sep: String,
     dest: String
   ): Argument[Boolean] = {
-    copy(name, alternatives, description, example, default, required, direction, multiple, multiple_sep, dest, `type`)
+    copy(name, alternatives, description, info, example, default, required, direction, multiple, multiple_sep, dest, `type`)
   }
 }
 
@@ -150,6 +160,14 @@ case class BooleanTrueArgument(
   @description("A description of the argument. This will be displayed with `--help`.")
   description: Option[String] = None,
 
+  @description("Structured information. Can be any shape: a string, vector, map or even nested map.")
+  @example(
+    """info:
+      |  category: cat1
+      |  labels: [one, two, three]""".stripMargin, "yaml")
+  @since("Viash 0.6.3")
+  info: Json = Json.Null,
+
   @undocumented
   direction: Direction = Input,
 
@@ -174,6 +192,7 @@ case class BooleanTrueArgument(
     name: String, 
     alternatives: OneOrMore[String],
     description: Option[String],
+    info: Json,
     default: OneOrMore[Boolean],
     example: OneOrMore[Boolean],
     required: Boolean,
@@ -182,7 +201,7 @@ case class BooleanTrueArgument(
     multiple_sep: String,
     dest: String
   ): Argument[Boolean] = {
-    copy(name, alternatives, description, direction, dest, `type`)
+    copy(name, alternatives, description, info, direction, dest, `type`)
   }
 }
 
@@ -211,6 +230,14 @@ case class BooleanFalseArgument(
   @description("A description of the argument. This will be displayed with `--help`.")
   description: Option[String] = None,
 
+  @description("Structured information. Can be any shape: a string, vector, map or even nested map.")
+  @example(
+    """info:
+      |  category: cat1
+      |  labels: [one, two, three]""".stripMargin, "yaml")
+  @since("Viash 0.6.3")
+  info: Json = Json.Null,
+
   @undocumented
   direction: Direction = Input,
 
@@ -236,6 +263,7 @@ case class BooleanFalseArgument(
     name: String, 
     alternatives: OneOrMore[String],
     description: Option[String],
+    info: Json,
     default: OneOrMore[Boolean],
     example: OneOrMore[Boolean],
     required: Boolean,
@@ -244,6 +272,6 @@ case class BooleanFalseArgument(
     multiple_sep: String,
     dest: String
   ): Argument[Boolean] = {
-    copy(name, alternatives, description, direction, dest, `type`)
+    copy(name, alternatives, description, info, direction, dest, `type`)
   }
 }

--- a/src/main/scala/io/viash/functionality/arguments/DoubleArgument.scala
+++ b/src/main/scala/io/viash/functionality/arguments/DoubleArgument.scala
@@ -17,6 +17,7 @@
 
 package io.viash.functionality.arguments
 
+import io.circe.Json
 import io.viash.helpers.data_structures._
 import io.viash.schemas._
 
@@ -45,6 +46,14 @@ case class DoubleArgument(
 
   @description("A description of the argument. This will be displayed with `--help`.")
   description: Option[String] = None,
+
+  @description("Structured information. Can be any shape: a string, vector, map or even nested map.")
+  @example(
+    """info:
+      |  category: cat1
+      |  labels: [one, two, three]""".stripMargin, "yaml")
+  @since("Viash 0.6.3")
+  info: Json = Json.Null,
 
   @description("An example value for this argument. If no [`default`](#default) property was specified, this will be used for that purpose.")
   @example(
@@ -123,6 +132,7 @@ case class DoubleArgument(
     name: String, 
     alternatives: OneOrMore[String],
     description: Option[String],
+    info: Json,
     example: OneOrMore[Double],
     default: OneOrMore[Double],
     required: Boolean,
@@ -131,6 +141,6 @@ case class DoubleArgument(
     multiple_sep: String,
     dest: String
   ): Argument[Double] = {
-    copy(name, alternatives, description, example, default, required, this.min, this.max, direction, multiple, multiple_sep, dest, `type`)
+    copy(name, alternatives, description, info, example, default, required, this.min, this.max, direction, multiple, multiple_sep, dest, `type`)
   }
 }

--- a/src/main/scala/io/viash/functionality/arguments/FileArgument.scala
+++ b/src/main/scala/io/viash/functionality/arguments/FileArgument.scala
@@ -17,6 +17,7 @@
 
 package io.viash.functionality.arguments
 
+import io.circe.Json
 import java.nio.file.Path
 import io.viash.helpers.data_structures._
 import io.viash.schemas._
@@ -46,6 +47,14 @@ case class FileArgument(
 
   @description("A description of the argument. This will be displayed with `--help`.")
   description: Option[String] = None,
+
+  @description("Structured information. Can be any shape: a string, vector, map or even nested map.")
+  @example(
+    """info:
+      |  category: cat1
+      |  labels: [one, two, three]""".stripMargin, "yaml")
+  @since("Viash 0.6.3")
+  info: Json = Json.Null,
 
   @description("An example value for this argument. If no [`default`](#default) property was specified, this will be used for that purpose.")
   @example(
@@ -121,6 +130,7 @@ case class FileArgument(
     name: String, 
     alternatives: OneOrMore[String],
     description: Option[String],
+    info: Json,
     example: OneOrMore[Path],
     default: OneOrMore[Path],
     required: Boolean,
@@ -129,6 +139,6 @@ case class FileArgument(
     multiple_sep: String,
     dest: String
   ): Argument[Path] = {
-    copy(name, alternatives, description, example, default, this.must_exist, required, direction, multiple, multiple_sep, dest, `type`)
+    copy(name, alternatives, description, info, example, default, this.must_exist, required, direction, multiple, multiple_sep, dest, `type`)
   }
 }

--- a/src/main/scala/io/viash/functionality/arguments/IntegerArgument.scala
+++ b/src/main/scala/io/viash/functionality/arguments/IntegerArgument.scala
@@ -17,6 +17,7 @@
 
 package io.viash.functionality.arguments
 
+import io.circe.Json
 import io.viash.helpers.data_structures._
 import io.viash.schemas._
 
@@ -45,6 +46,14 @@ case class IntegerArgument(
 
   @description("A description of the argument. This will be displayed with `--help`.")
   description: Option[String] = None,
+
+  @description("Structured information. Can be any shape: a string, vector, map or even nested map.")
+  @example(
+    """info:
+      |  category: cat1
+      |  labels: [one, two, three]""".stripMargin, "yaml")
+  @since("Viash 0.6.3")
+  info: Json = Json.Null,
 
   @description("An example value for this argument. If no [`default`](#default) property was specified, this will be used for that purpose.")
   @example(
@@ -132,6 +141,7 @@ case class IntegerArgument(
     name: String, 
     alternatives: OneOrMore[String],
     description: Option[String],
+    info: Json,
     example: OneOrMore[Int],
     default: OneOrMore[Int],
     required: Boolean,
@@ -140,6 +150,6 @@ case class IntegerArgument(
     multiple_sep: String,
     dest: String
   ): Argument[Int] = {
-    copy(name, alternatives, description, example, default, required, this.choices, this.min, this.max, direction, multiple, multiple_sep, dest, `type`)
+    copy(name, alternatives, description, info, example, default, required, this.choices, this.min, this.max, direction, multiple, multiple_sep, dest, `type`)
   }
 }

--- a/src/main/scala/io/viash/functionality/arguments/LongArgument.scala
+++ b/src/main/scala/io/viash/functionality/arguments/LongArgument.scala
@@ -17,6 +17,7 @@
 
 package io.viash.functionality.arguments
 
+import io.circe.Json
 import io.viash.helpers.data_structures._
 import io.viash.schemas._
 
@@ -46,6 +47,14 @@ case class LongArgument(
 
   @description("A description of the argument. This will be displayed with `--help`.")
   description: Option[String] = None,
+
+  @description("Structured information. Can be any shape: a string, vector, map or even nested map.")
+  @example(
+    """info:
+      |  category: cat1
+      |  labels: [one, two, three]""".stripMargin, "yaml")
+  @since("Viash 0.6.3")
+  info: Json = Json.Null,
 
   @description("An example value for this argument. If no [`default`](#default) property was specified, this will be used for that purpose.")
   @example(
@@ -133,6 +142,7 @@ case class LongArgument(
     name: String, 
     alternatives: OneOrMore[String],
     description: Option[String],
+    info: Json,
     example: OneOrMore[Long],
     default: OneOrMore[Long],
     required: Boolean,
@@ -141,6 +151,6 @@ case class LongArgument(
     multiple_sep: String,
     dest: String
   ): Argument[Long] = {
-    copy(name, alternatives, description, example, default, required, this.choices, this.min, this.max, direction, multiple, multiple_sep, dest, `type`)
+    copy(name, alternatives, description, info, example, default, required, this.choices, this.min, this.max, direction, multiple, multiple_sep, dest, `type`)
   }
 }

--- a/src/main/scala/io/viash/functionality/arguments/StringArgument.scala
+++ b/src/main/scala/io/viash/functionality/arguments/StringArgument.scala
@@ -17,6 +17,7 @@
 
 package io.viash.functionality.arguments
 
+import io.circe.Json
 import io.viash.helpers.data_structures._
 import io.viash.schemas._
 
@@ -45,6 +46,14 @@ case class StringArgument(
 
   @description("A description of the argument. This will be displayed with `--help`.")
   description: Option[String] = None,
+
+  @description("Structured information. Can be any shape: a string, vector, map or even nested map.")
+  @example(
+    """info:
+      |  category: cat1
+      |  labels: [one, two, three]""".stripMargin, "yaml")
+  @since("Viash 0.6.3")
+  info: Json = Json.Null,
   
   @description("An example value for this argument. If no [`default`](#default) property was specified, this will be used for that purpose.")
   @example(
@@ -114,6 +123,7 @@ case class StringArgument(
     name: String, 
     alternatives: OneOrMore[String],
     description: Option[String],
+    info: Json,
     example: OneOrMore[String],
     default: OneOrMore[String],
     required: Boolean,
@@ -122,6 +132,6 @@ case class StringArgument(
     multiple_sep: String,
     dest: String
   ): Argument[String] = {
-    copy(name, alternatives, description, example, default, required, this.choices, direction, multiple, multiple_sep, dest, `type`)
+    copy(name, alternatives, description, info, example, default, required, this.choices, direction, multiple, multiple_sep, dest, `type`)
   }
 }

--- a/src/test/scala/io/viash/functionality/FunctionalityTest.scala
+++ b/src/test/scala/io/viash/functionality/FunctionalityTest.scala
@@ -1,0 +1,49 @@
+package io.viash.functionality
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import java.nio.file.{Files, Paths, StandardCopyOption}
+import scala.util.Try
+import io.circe._
+import io.circe.yaml.{parser => YamlParser}
+import io.circe.syntax._
+import io.viash.helpers.circe._
+import io.viash.helpers.data_structures._
+
+
+class FunctionalityTest extends FunSuite with BeforeAndAfterAll {
+  val infoJson = Yaml("""
+    |foo:
+    |  bar:
+    |    baz:
+    |      10
+    |arg: aaa
+    |""".stripMargin)
+
+  test("Simple getters and helper functions") {
+    val fun = Functionality(name = "foo")
+
+    assert(fun.name == "foo")
+    assert(fun.description == None)
+    assert(fun.info == Json.Null)
+
+    val funParsed = fun.asJson.as[Functionality].fold(throw _, a => a)
+    assert(funParsed == fun)
+  }
+
+  test("Simple getters and helper functions on object with many non-default values") {
+    val fun = Functionality(
+      name = "one_two_three_four",
+      description = Some("foo"),
+      info = infoJson
+    )
+
+    assert(fun.name == "one_two_three_four")
+    assert(fun.description == Some("foo"))
+    assert(fun.info == infoJson)
+    
+    val funParsed = fun.asJson.as[Functionality].fold(throw _, a => a)
+    assert(funParsed == fun)
+  }
+
+  // TODO: expand functionality tests
+}

--- a/src/test/scala/io/viash/functionality/arguments/StringArgumentSuite.scala
+++ b/src/test/scala/io/viash/functionality/arguments/StringArgumentSuite.scala
@@ -3,9 +3,21 @@ package io.viash.functionality.arguments
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import java.nio.file.{Files, Paths, StandardCopyOption}
 import scala.util.Try
+import io.circe.Json
+import io.circe.JsonObject
+import io.circe.yaml.{parser => YamlParser}
+import io.viash.helpers.circe._
 import io.viash.helpers.data_structures._
 
+
 class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
+  val infoJson = Yaml("""
+    |foo:
+    |  bar:
+    |    baz:
+    |      10
+    |arg: aaa
+    |""".stripMargin)
 
   test("Simple getters and helper functions") {
     val arg = StringArgument(name = "--foo")
@@ -19,6 +31,7 @@ class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
     assert(arg.name == "--foo")
     assert(arg.alternatives == OneOrMore())
     assert(arg.description == None)
+    assert(arg.info == Json.Null)
     assert(arg.example == OneOrMore())
     assert(arg.default == OneOrMore())
     assert(!arg.required)
@@ -34,6 +47,7 @@ class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
       name = "one_two_three_four",
       alternatives = List("zero", "-one", "--two"),
       description = Some("foo"),
+      info = infoJson,
       example = OneOrMore("ten"),
       default = OneOrMore("bar"),
       required = true,
@@ -53,6 +67,7 @@ class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
     assert(arg.name == "one_two_three_four")
     assert(arg.alternatives == OneOrMore("zero", "-one", "--two"))
     assert(arg.description == Some("foo"))
+    assert(arg.info == infoJson)
     assert(arg.example == OneOrMore("ten"))
     assert(arg.default == OneOrMore("bar"))
     assert(arg.required)
@@ -70,6 +85,7 @@ class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
       name = "one_two_three_four",
       alternatives = List("zero", "-one", "--two"),
       description = Some("foo"),
+      info = infoJson,
       example = OneOrMore("ten"),
       default = OneOrMore("bar"),
       required = true,
@@ -85,6 +101,7 @@ class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
     assert(arg2.name == "one_two_three_four")
     assert(arg2.alternatives == OneOrMore("zero", "-one", "--two"))
     assert(arg2.description == Some("foo"))
+    assert(arg2.info == infoJson)
     assert(arg2.example == OneOrMore("ten"))
     assert(arg2.default == OneOrMore("bar"))
     assert(arg2.required)

--- a/src/test/scala/io/viash/functionality/arguments/StringArgumentTest.scala
+++ b/src/test/scala/io/viash/functionality/arguments/StringArgumentTest.scala
@@ -3,14 +3,14 @@ package io.viash.functionality.arguments
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import java.nio.file.{Files, Paths, StandardCopyOption}
 import scala.util.Try
-import io.circe.Json
-import io.circe.JsonObject
+import io.circe._
+import io.circe.syntax._
 import io.circe.yaml.{parser => YamlParser}
 import io.viash.helpers.circe._
 import io.viash.helpers.data_structures._
 
 
-class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
+class StringArgumentTest extends FunSuite with BeforeAndAfterAll {
   val infoJson = Yaml("""
     |foo:
     |  bar:
@@ -40,6 +40,9 @@ class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
     assert(!arg.multiple)
     assert(arg.multiple_sep == ":")
     assert(arg.dest == "par")
+
+    val argParsed = arg.asJson.as[StringArgument].fold(throw _, a => a)
+    assert(argParsed == arg)
   }
 
   test("Simple getters and helper functions on object with many non-default values") {
@@ -76,6 +79,9 @@ class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
     assert(arg.multiple)
     assert(arg.multiple_sep == "-")
     assert(arg.dest == "meta")
+
+    val argParsed = arg.asJson.as[StringArgument].fold(throw _, a => a)
+    assert(argParsed == arg)
   }
 
   test("copyArg helper function") {
@@ -95,6 +101,9 @@ class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
       dest = "meta"
     )
 
+    val arg2GParsed = arg2generic.asJson.as[Argument[_]].fold(throw _, a => a)
+    assert(arg2GParsed == arg2generic)
+
     assert(arg2generic.isInstanceOf[StringArgument])
     val arg2 = arg2generic.asInstanceOf[StringArgument]
 
@@ -110,5 +119,8 @@ class StringArgumentSuite extends FunSuite with BeforeAndAfterAll {
     assert(arg2.multiple)
     assert(arg2.multiple_sep == "-")
     assert(arg2.dest == "meta")
+
+    val arg2Parsed = arg2.asJson.as[StringArgument].fold(throw _, a => a)
+    assert(arg2Parsed == arg2)
   }
 }

--- a/src/test/scala/io/viash/helpers/circe/JMapTest.scala
+++ b/src/test/scala/io/viash/helpers/circe/JMapTest.scala
@@ -1,0 +1,27 @@
+package io.viash.helpers.circe
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import io.circe._
+import io.circe.yaml.{parser => YamlParser}
+
+class JMapTest extends FunSuite with BeforeAndAfterAll {
+  test("checking whether JMap works") {
+    val out = JMap(
+      "foo" -> JMap(
+        "bar" -> JMap(
+          "baz" -> Json.fromInt(10)
+        )
+      ), 
+      "arg" -> Json.fromString("aaa")
+    )
+    val expectedOut = Yaml("""
+      |foo:
+      |  bar:
+      |    baz:
+      |      10
+      |arg: aaa
+      """.stripMargin)
+
+    assert(out == expectedOut)
+  }
+}

--- a/src/test/scala/io/viash/helpers/circe/YamlTest.scala
+++ b/src/test/scala/io/viash/helpers/circe/YamlTest.scala
@@ -1,0 +1,27 @@
+package io.viash.helpers.circe
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import io.circe._
+import io.circe.yaml.{parser => YamlParser}
+
+class YamlTest extends FunSuite with BeforeAndAfterAll {
+  test("checking whether Yaml works") {
+    val out = Yaml("""
+      |foo:
+      |  bar:
+      |    baz:
+      |      10
+      |arg: aaa
+      """.stripMargin)
+    val expectedOut = Json.fromJsonObject(JsonObject(
+      "foo" -> Json.fromJsonObject(JsonObject(
+        "bar" -> Json.fromJsonObject(JsonObject(
+          "baz" -> Json.fromInt(10)
+        ))
+      )),
+      "arg" -> Json.fromString("aaa")
+    ))
+
+    assert(out == expectedOut)
+  }
+}


### PR DESCRIPTION
At the moment, the info field in functionality can only be a `Map[String, String]`. This PR changes that to a Json, so it can have an arbitrary structure. The same info fields are added for arguments.

Changelog:

* `Functionality`: Structured annotation can be added to a functionality and its arguments using the `info` field. Example:
  ```yaml
  functionality:
    name: foo
    info:
      site: https://abc.xyz
      tags: [ one, two, three ]
    arguments:
      - name: --foo
        type: string
        info:
          foo: bar
          a:
            b:
              c
  ```

To do:

- [ ] Discuss whether to print the structured information during `--help`? I'm a little bit in favour of not printing it
- [x] Add unit tests
- [x] Update changelog