### PR TITLE
Config inheritance: Allow specifying the order of config inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+# Viash 0.6.4
+
+## MINOR CHANGES
+
+* Config inheritance: Allow specifying the order of config inheritance. 
+  If `.` is not in the list of inherited objects, it will be added at the end.
+
+  Contents of `config.vsh.yaml`:
+  ```yaml
+  functionality:
+  name: foo
+  arguments:
+    - __inherits__: obj_input.yaml
+      name: "--one"
+    - __inherits__: [., obj_input.yaml]
+      name: "--two"
+    - __inherits__: [obj_input.yaml, .]
+      name: "--three"
+  ```
+  Contents of `obj_input.yaml`:
+  ```yaml
+  type: file
+  name: --input
+  description: A h5ad file
+  ```
+  Output of `viash config view config.vsh.yaml` (stripped irrelevant bits):
+  ```yaml
+  functionality:
+    arguments:
+    - type: "file"
+      name: "--one"
+      description: "A h5ad file"
+    - type: "file"
+      name: "--input"
+      description: "A h5ad file"
+    - type: "file"
+      name: "--three"
+      description: "A h5ad file"
+  ```
+
 # Viash 0.6.3
 
 This release features contains mostly quality of life improvements and some experimental functionality. Most notably:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## MINOR CHANGES
 
-* Config inheritance: Allow specifying the order of config inheritance. 
+* Config inheritance: Allow specifying the order of config inheritance (#289).
   If `.` is not in the list of inherited objects, it will be added at the end.
 
   Contents of `config.vsh.yaml`:

--- a/src/main/scala/io/viash/helpers/circe/RichJson.scala
+++ b/src/main/scala/io/viash/helpers/circe/RichJson.scala
@@ -106,6 +106,8 @@ class RichJson(json: Json) {
     }
   }
 
+  private val inheritsTag = "__inherits__"
+
   /**
    * Recursively resolve inheritance within Json objects.
    * 
@@ -116,51 +118,70 @@ class RichJson(json: Json) {
     json match {
       case x if x.isObject =>
         val obj1 = x.asObject.get
-        val obj2 = obj1.apply("__inherits__") match {
+        val obj2 = obj1.apply(inheritsTag) match {
           case Some(y) if y.isString || y.isArray =>
-            // resolve uri
-            val uriStrs = 
+            // get includes
+            val inheritStrs0 = 
               if (y.isString) {
                 List(y.asString.get)
               } else {
                 // TODO: add decent error message instead of simply .get
                 y.asArray.get.map(_.asString.get).toList
               }
-            val uris = uriStrs.map(uri.resolve(_))
             
-            // remove inherits field from obj1
-            val obj1rem = Json.fromJsonObject(
+            // add self as last element if it is not already explicitly defined
+            val inheritStrs1 =
+              if (inheritStrs0.contains(".")) {
+                inheritStrs0
+              } else {
+                inheritStrs0 ::: List(".")
+              }
+
+            // fetch uris
+            val uris = inheritStrs1.map{str =>
+              if (str == ".") {
+                None
+              } else {
+                Some(uri.resolve(str))
+              }
+            }
+            
+            // remove inherits field from obj1 if so desired, else replace with absolute paths
+            val self = Json.fromJsonObject(
               if (stripInherits) {
-                obj1.remove("__inherits__")
+                obj1.remove(inheritsTag)
               } else {
                 // replace __inherits__ with absolute path using deepMerge
-                val uriJsons = uris.map(uri => Json.fromString(uri.toString))
-                val newInherits = if (y.isString) uriJsons.head else Json.fromValues(uriJsons)
-                val newObj = JsonObject("__inherits__" -> newInherits)
+                val uriJsons = uris.map{
+                  case None => Json.fromString(".")
+                  case Some(uri) => Json.fromString(uri.toString)
+                }
+                val newInherits = Json.fromValues(uriJsons)
+                val newObj = JsonObject(inheritsTag -> newInherits)
                 obj1 deepMerge newObj
               }
             )
 
-            // recurse through new json as well
-            val newJsons = uris.map(newURI => {
-              // read as string
-              val str = IO.read(newURI)
+            // generate list of jsons to merge
+            // don't forget to resolve inheritance recursively
+            val jsonsToMerge = uris.map{
+              case None => self
+              case Some(newURI) =>
+                // read as string
+                val str = IO.read(newURI)
 
-              // parse as yaml
-              // TODO: add decent error message instead of simply .get
-              val newJson1 = io.circe.yaml.parser.parse(str).right.get
+                // parse as yaml
+                // TODO: add decent error message instead of simply .get
+                val newJson1 = io.circe.yaml.parser.parse(str).right.get
 
-              // recurse through new json as well
-              val newJson2 = newJson1.inherit(newURI)
+                // recurse through new json as well
+                val newJson2 = newJson1.inherit(newURI)
 
-              newJson2
-            })
+                newJson2
+            }
 
-            // merge with orig object
-            val jsMerged = 
-              newJsons.foldLeft(obj1rem) { (oldJs, newJs) => 
-                oldJs.concatDeepMerge(newJs)
-              }
+            // merge jsons
+            val jsMerged = jsonsToMerge.reduce{_ concatDeepMerge _}
 
             // return combined object
             jsMerged.asObject.get
@@ -180,7 +201,7 @@ class RichJson(json: Json) {
   def stripInherits: Json = {
     json
       .mapObject{
-        _.mapValues(_.stripInherits).filter(_._1 != "__inherits__")
+        _.mapValues(_.stripInherits).filter(_._1 != inheritsTag)
       }
       .mapArray(
         _.map(_.stripInherits)

--- a/src/test/scala/io/viash/helpers/circe/RichJsonTest.scala
+++ b/src/test/scala/io/viash/helpers/circe/RichJsonTest.scala
@@ -86,7 +86,7 @@ class RichJsonTest extends FunSuite with BeforeAndAfterAll {
     assert(jsonMerge == jsonMergeExpected)
   }
 
-  test("checking whether inherit works") {
+  test("inherit with implicit ordering") {
     // write json to file
     IO.write("a: [3, 4]", temporaryFolder.resolve("obj1.yaml"))
 
@@ -95,17 +95,52 @@ class RichJsonTest extends FunSuite with BeforeAndAfterAll {
       |a: [1, 2]
       |""".stripMargin
     ).getOrElse(Json.Null)
-    val jsonExpected = parser.parse("""
+    val jsonExpected1 = parser.parse("""
+      |a: [3, 4, 1, 2]
+      |""".stripMargin
+    ).getOrElse(Json.Null)
+
+    val jsonOut1 = json1.inherit(temporaryFolder.toUri())
+    assert(jsonOut1 == jsonExpected1)
+  }
+
+  test("inherit with explicit ordering") {
+    // write json to file
+    IO.write("a: [3, 4]", temporaryFolder.resolve("obj1.yaml"))
+
+    val json1 = parser.parse("""
+      |__inherits__: [obj1.yaml, .]
+      |a: [1, 2]
+      |""".stripMargin
+    ).getOrElse(Json.Null)
+    val jsonExpected1 = parser.parse("""
+      |a: [3, 4, 1, 2]
+      |""".stripMargin
+    ).getOrElse(Json.Null)
+
+    val jsonOut1 = json1.inherit(temporaryFolder.toUri())
+    assert(jsonOut1 == jsonExpected1)
+  }
+
+  test("inherit with explicit ordering reversed") {
+    // write json to file
+    IO.write("a: [3, 4]", temporaryFolder.resolve("obj1.yaml"))
+
+    val json1 = parser.parse("""
+      |__inherits__: [., obj1.yaml]
+      |a: [1, 2]
+      |""".stripMargin
+    ).getOrElse(Json.Null)
+    val jsonExpected1 = parser.parse("""
       |a: [1, 2, 3, 4]
       |""".stripMargin
     ).getOrElse(Json.Null)
 
-    // check whether filling default works
-    val jsonOut = json1.inherit(temporaryFolder.toUri())
-    assert(jsonOut == jsonExpected)
+    val jsonOut1 = json1.inherit(temporaryFolder.toUri())
+    assert(jsonOut1 == jsonExpected1)
   }
 
-  test("checking whether inherit without stripping the inherits works") {
+  test("inherit without stripping the inherits") {
     // write json to file
     val obj1Path = temporaryFolder.resolve("obj1.yaml")
     IO.write("a: [3, 4]", obj1Path)
@@ -116,8 +151,8 @@ class RichJsonTest extends FunSuite with BeforeAndAfterAll {
       |""".stripMargin
     ).getOrElse(Json.Null)
     val jsonExpected = parser.parse(s"""
-      |__inherits__: file:${obj1Path}
-      |a: [1, 2, 3, 4]
+      |__inherits__: [ file:${obj1Path}, . ]
+      |a: [3, 4, 1, 2]
       |""".stripMargin
     ).getOrElse(Json.Null)
 
@@ -126,7 +161,7 @@ class RichJsonTest extends FunSuite with BeforeAndAfterAll {
     assert(jsonOut == jsonExpected)
   }
 
-  test("checking whether multiple inheritance works") {
+  test("multiple inheritance") {
     IO.write("a: [3]", temporaryFolder.resolve("obj2.yaml"))
     IO.write("a: [4]", temporaryFolder.resolve("obj3.yaml"))
 
@@ -136,7 +171,7 @@ class RichJsonTest extends FunSuite with BeforeAndAfterAll {
       |""".stripMargin
     ).getOrElse(Json.Null)
     val jsonExpected = parser.parse("""
-      |a: [1, 2, 3, 4]
+      |a: [3, 4, 1, 2]
       |""".stripMargin
     ).getOrElse(Json.Null)
 
@@ -157,7 +192,7 @@ class RichJsonTest extends FunSuite with BeforeAndAfterAll {
       |""".stripMargin
     ).getOrElse(Json.Null)
     val jsonExpected = parser.parse("""
-      |a: [1, 2, 3, 4]
+      |a: [4, 3, 1, 2]
       |""".stripMargin
     ).getOrElse(Json.Null)
 


### PR DESCRIPTION
Config inheritance: Allow specifying the order of config inheritance. 
If `.` is not in the list of inherited objects, it will be added at the end.

Contents of `config.vsh.yaml`:
```yaml
functionality:
  name: foo
  arguments:
    - __inherits__: obj_input.yaml
      name: "--one"
    - __inherits__: [., obj_input.yaml]
      name: "--two"
    - __inherits__: [obj_input.yaml, .]
      name: "--three"
```
Contents of `obj_input.yaml`:
```yaml
type: file
name: --input
description: A h5ad file
```
Output of `viash config view config.vsh.yaml` (stripped irrelevant bits):
```yaml
functionality:
  name: foo
  arguments:
  - type: "file"
    name: "--one"
    description: "A h5ad file"
  - type: "file"
    name: "--input"
    description: "A h5ad file"
  - type: "file"
    name: "--three"
    description: "A h5ad file"
```