### PR TITLE
Fix/yaml in viash run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Config: Viash configs whose paths start with a `.` are ignored.
 
+* `viash build`: `--write_meta` argument has been removed. Instead,the `.config.vsh.yaml` file is always created when building Viash components.
+
 ## NEW FUNCTIONALITY
 
 * Traceability: Running `viash build` and `viash test` creates a `.config.vsh.yaml` file by default, which contains the processed config of the component. As a side effect, this allows for reading in the `.config.vsh.yaml` from within the component to learn more about the component being tested.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Config: Viash configs whose paths start with a `.` are ignored.
 
-* `viash build`: `--write_meta` argument has been removed. Instead,the `.config.vsh.yaml` file is always created when building Viash components.
+* `viash build`: `--write_meta` and `--print_meta` arguments have been removed. 
+  Instead, the `.config.vsh.yaml` file is always created when building Viash components.
 
 ## NEW FUNCTIONALITY
 

--- a/src/main/scala/io/viash/Main.scala
+++ b/src/main/scala/io/viash/Main.scala
@@ -83,7 +83,6 @@ object Main {
           config = config,
           platform = platform.get,
           output = cli.build.output(),
-          printMeta = cli.build.printMeta(),
           setup = cli.build.setup.toOption,
           push = cli.build.push()
         )

--- a/src/main/scala/io/viash/Main.scala
+++ b/src/main/scala/io/viash/Main.scala
@@ -84,7 +84,6 @@ object Main {
           platform = platform.get,
           output = cli.build.output(),
           printMeta = cli.build.printMeta(),
-          writeMeta = cli.build.writeMeta(),
           setup = cli.build.setup.toOption,
           push = cli.build.push()
         )
@@ -107,7 +106,6 @@ object Main {
           setup = cli.namespace.build.setup.toOption,
           push = cli.namespace.build.push(),
           parallel = cli.namespace.build.parallel(),
-          writeMeta = cli.namespace.build.writeMeta(),
           flatten = cli.namespace.build.flatten()
         )
         0 // Might be possible to be improved further.

--- a/src/main/scala/io/viash/ViashBuild.scala
+++ b/src/main/scala/io/viash/ViashBuild.scala
@@ -29,7 +29,6 @@ object ViashBuild {
     config: Config,
     platform: Platform,
     output: String,
-    writeMeta: Boolean = false,
     printMeta: Boolean = false,
     setup: Option[String] = None,
     push: Boolean = false
@@ -47,11 +46,7 @@ object ViashBuild {
     val configYaml = ConfigMeta.toMetaFile(config, Some(dir))
 
     // write resources to output directory
-    if (writeMeta) {
-      IO.writeResources(configYaml :: fun.resources, dir)
-    } else {
-      IO.writeResources(fun.resources, dir)
-    }
+    IO.writeResources(configYaml :: fun.resources, dir)
 
     // if '--setup <strat>' was passed, run './executable ---setup <strat>'
     if (setup.isDefined && exec_path.isDefined && platform.hasSetup) {

--- a/src/main/scala/io/viash/ViashBuild.scala
+++ b/src/main/scala/io/viash/ViashBuild.scala
@@ -43,17 +43,8 @@ object ViashBuild {
     // get the path of where the executable will be written to
     val exec_path = fun.mainScript.map(scr => Paths.get(output, scr.resourcePath).toString)
 
-    // change the config object before writing to yaml:
-    // * add more info variables
-    val toWriteConfig = config.copy(
-      info = config.info.map(_.copy(
-        output = Some(output),
-        executable = exec_path
-      ))
-    )
-
     // convert config to a yaml wrapped inside a PlainFile
-    val configYaml = ConfigMeta.toMetaFile(toWriteConfig)
+    val configYaml = ConfigMeta.toMetaFile(config, Some(dir))
 
     // write resources to output directory
     if (writeMeta) {
@@ -76,7 +67,7 @@ object ViashBuild {
 
     // if '-m' was passed, print some yaml about the created output fields
     if (printMeta) {
-      println(toWriteConfig.info.get.consoleString)
+      println(config.info.get.consoleString)
     }
   }
 }

--- a/src/main/scala/io/viash/ViashBuild.scala
+++ b/src/main/scala/io/viash/ViashBuild.scala
@@ -29,7 +29,6 @@ object ViashBuild {
     config: Config,
     platform: Platform,
     output: String,
-    printMeta: Boolean = false,
     setup: Option[String] = None,
     push: Boolean = false
   ) {
@@ -58,11 +57,6 @@ object ViashBuild {
     if (push && exec_path.isDefined && platform.hasSetup) {
       val cmd = Array(exec_path.get, "---setup push")
       val _ = Process(cmd).!(ProcessLogger(println, println))
-    }
-
-    // if '-m' was passed, print some yaml about the created output fields
-    if (printMeta) {
-      println(config.info.get.consoleString)
     }
   }
 }

--- a/src/main/scala/io/viash/ViashNamespace.scala
+++ b/src/main/scala/io/viash/ViashNamespace.scala
@@ -37,7 +37,6 @@ object ViashNamespace {
     setup: Option[String] = None,
     push: Boolean = false,
     parallel: Boolean = false,
-    writeMeta: Boolean = true,
     flatten: Boolean = false
   ) {
     val configs2 = if (parallel) configs.par else configs
@@ -63,8 +62,7 @@ object ViashNamespace {
             platform = platform,
             output = out,
             setup = setup,
-            push = push,
-            writeMeta = writeMeta
+            push = push
           )
           Right(Success)
         }

--- a/src/main/scala/io/viash/ViashRun.scala
+++ b/src/main/scala/io/viash/ViashRun.scala
@@ -42,12 +42,28 @@ object ViashRun {
     // execute command, print everything to console
     var code = -1
     try {
+
+      // get the path of where the executable will be written to
+      val exec_path = Paths.get(dir.toString, fun.name)
+
+      // change the config object before writing to yaml:
+      // * add more info variables
+      val toWriteConfig = config.copy(
+        info = config.info.map(_.copy(
+          output = Some(dir.toString),
+          executable = Some(exec_path.toString)
+        ))
+      )
+
+      // convert config to a yaml wrapped inside a PlainFile
+      val configYaml = ConfigMeta.toMetaFile(toWriteConfig)
+
       // write executable and resources to temporary directory
-      IO.writeResources(fun.resources, dir)
+      IO.writeResources(configYaml :: fun.resources, dir)
 
       // determine command
       val cmd =
-        Array(Paths.get(dir.toString, fun.name).toString) ++ 
+        Array(exec_path.toString) ++ 
         args ++ 
         Array(cpus.map("---cpus=" + _), memory.map("---memory="+_)).flatMap(a => a)
 

--- a/src/main/scala/io/viash/ViashRun.scala
+++ b/src/main/scala/io/viash/ViashRun.scala
@@ -42,28 +42,15 @@ object ViashRun {
     // execute command, print everything to console
     var code = -1
     try {
-
-      // get the path of where the executable will be written to
-      val exec_path = Paths.get(dir.toString, fun.name)
-
-      // change the config object before writing to yaml:
-      // * add more info variables
-      val toWriteConfig = config.copy(
-        info = config.info.map(_.copy(
-          output = Some(dir.toString),
-          executable = Some(exec_path.toString)
-        ))
-      )
-
       // convert config to a yaml wrapped inside a PlainFile
-      val configYaml = ConfigMeta.toMetaFile(toWriteConfig)
+      val configYaml = ConfigMeta.toMetaFile(config, Some(dir))
 
       // write executable and resources to temporary directory
       IO.writeResources(configYaml :: fun.resources, dir)
 
       // determine command
       val cmd =
-        Array(exec_path.toString) ++ 
+        Array(Paths.get(dir.toString, fun.name).toString) ++ 
         args ++ 
         Array(cpus.map("---cpus=" + _), memory.map("---memory="+_)).flatMap(a => a)
 

--- a/src/main/scala/io/viash/ViashTest.scala
+++ b/src/main/scala/io/viash/ViashTest.scala
@@ -247,7 +247,7 @@ object ViashTest {
           dest = Some("test_executable"),
           text = funOnlyTest.resources.head.text
         )
-        val configYaml = ConfigMeta.toMetaFile(config)
+        val configYaml = ConfigMeta.toMetaFile(config, Some(dir))
 
         // assemble full resources list for test
         val funFinal = fun.copy(resources = 

--- a/src/main/scala/io/viash/cli/CLIConf.scala
+++ b/src/main/scala/io/viash/cli/CLIConf.scala
@@ -180,12 +180,6 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) {
       "Build an executable from the provided viash config file.",
       "viash build config.vsh.yaml -o output [-p docker] [-m] [-s]")
 
-    val printMeta = registerOpt[Boolean](
-      name = "meta",
-      short = Some('m'),
-      default = Some(false),
-      descr = "Print out some meta information at the end."
-    )
     val output = registerOpt[String](
       name = "output",
       short = Some('o'),

--- a/src/main/scala/io/viash/cli/CLIConf.scala
+++ b/src/main/scala/io/viash/cli/CLIConf.scala
@@ -186,12 +186,6 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) {
       default = Some(false),
       descr = "Print out some meta information at the end."
     )
-    val writeMeta = registerOpt[Boolean](
-      name = "write_meta",
-      short = Some('w'),
-      default = Some(true),
-      descr = "Write out some meta information to `<output>/.config.vsh.yaml`."
-    )
     val output = registerOpt[String](
       name = "output",
       short = Some('o'),
@@ -282,12 +276,6 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) {
         name = "push",
         default = Some(false),
         descr = "Whether or not to push the container to a Docker registry [Docker Platform only]."
-      )
-      val writeMeta = registerOpt[Boolean](
-        name = "write_meta",
-        short = Some('w'),
-        default = Some(true),
-        descr = "Write out some meta information to `<output>/.config.vsh.yaml`."
       )
       val flatten = registerOpt[Boolean](
         name = "flatten",

--- a/src/main/scala/io/viash/config/ConfigMeta.scala
+++ b/src/main/scala/io/viash/config/ConfigMeta.scala
@@ -60,7 +60,7 @@ object ConfigMeta {
         }
       ),
       info = config.info.map(_.copy(
-        output = Some(dir.toString),
+        output = dir.map(_.toString),
         executable = dir.map(d => Paths.get(d.toString, config.functionality.name).toString)
       ))
     )

--- a/src/main/scala/io/viash/config/Info.scala
+++ b/src/main/scala/io/viash/config/Info.scala
@@ -26,19 +26,4 @@ case class Info(
   git_commit: Option[String] = None,
   git_remote: Option[String] = None,
   git_tag: Option[String] = None
-) {
-  def consoleString: String = {
-    val missing = "<NA>"
-    s"""viash version:      ${viash_version.getOrElse(missing)}
-       |config:             ${config}
-       |platform:           ${platform.getOrElse(missing)}
-       |executable:         ${executable.getOrElse(missing)}
-       |output:             ${output.getOrElse(missing)}
-       |remote git repo:    ${git_remote.getOrElse(missing)}""".stripMargin
-  }
-
-  def parent_path: String = {
-    val regex = "[^/]*$".r
-    regex.replaceFirstIn(config, "")
-  }
-}
+)

--- a/src/test/scala/io/viash/MainBuildDockerSuite.scala
+++ b/src/test/scala/io/viash/MainBuildDockerSuite.scala
@@ -192,28 +192,33 @@ class MainBuildDockerSuite extends FunSuite with BeforeAndAfterAll {
         "build",
         "-p", "docker",
         "-o", tempFolStr,
-        "-m",
         configMetaFile
       )
-
+      
+      // check exec
       assert(executable.exists)
       assert(executable.canExecute)
 
+      // check meta
+      val meta = temporaryFolder.resolve(".config.vsh.yaml")
+      assert(meta.toFile.exists)
+      val metaStr = scala.io.Source.fromFile(meta.toFile).getLines.mkString("\n")
+
       val viashVersion = io.viash.Main.version
 
-      val regexViashVersion = s"viash version:\\s*$viashVersion".r
-      val regexConfig = s"config:\\s*$configMetaFile".r
-      val regexPlatform = "platform:\\s*docker".r
-      val regexExecutable = s"executable:\\s*$tempFolStr/testbash".r
-      val regexOutput = s"output:\\s*$tempFolStr".r
-      val regexNoRemoteGitRepo = "remote git repo:\\s*<NA>".r
+      val regexViashVersion = s"""viash_version: "${viashVersion}"""".r
+      val regexConfig = s"""config: "${configMetaFile}"""".r
+      val regexPlatform = """platform: "docker"""".r
+      val regexExecutable = s"""executable: "$tempFolStr/testbash"""".r
+      val regexOutput = s"""output: "$tempFolStr"""".r
+      val regexNoRemoteGitRepo = "git_remote:".r
 
-      assert(regexViashVersion.findFirstIn(stdout).isDefined, stdout)
-      assert(regexConfig.findFirstIn(stdout).isDefined, stdout)
-      assert(regexPlatform.findFirstIn(stdout).isDefined, stdout)
-      assert(regexExecutable.findFirstIn(stdout).isDefined, stdout)
-      assert(regexOutput.findFirstIn(stdout).isDefined, stdout)
-      assert(regexNoRemoteGitRepo.findFirstIn(stdout).isDefined, stdout)
+      assert(regexViashVersion.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexConfig.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexPlatform.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexExecutable.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexOutput.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexNoRemoteGitRepo.findFirstIn(metaStr).isEmpty, stdout)
 
     }
     finally {
@@ -261,28 +266,33 @@ class MainBuildDockerSuite extends FunSuite with BeforeAndAfterAll {
         "build",
         "-p", "docker",
         "-o", tempFolStr,
-        "-m",
         configMetaFile
       )
-
+      
+      // check exec
       assert(executable.exists)
       assert(executable.canExecute)
 
+      // check meta
+      val meta = temporaryFolder.resolve(".config.vsh.yaml")
+      assert(meta.toFile.exists)
+      val metaStr = scala.io.Source.fromFile(meta.toFile).getLines.mkString("\n")
+
       val viashVersion = io.viash.Main.version
 
-      val regexViashVersion = s"viash version:\\s*$viashVersion".r
-      val regexConfig = s"config:\\s*$configMetaFile".r
-      val regexPlatform = "platform:\\s*docker".r
-      val regexExecutable = s"executable:\\s*$tempFolStr/testbash".r
-      val regexOutput = s"output:\\s*$tempFolStr".r
-      val regexRemoteGitRepo = s"remote git repo:\\s*$fakeGitRepo".r
+      val regexViashVersion = s"""viash_version: "$viashVersion"""".r
+      val regexConfig = s"""config: "$configMetaFile"""".r
+      val regexPlatform = """platform: "docker"""".r
+      val regexExecutable = s"""executable: "$tempFolStr/testbash"""".r
+      val regexOutput = s"""output: "$tempFolStr"""".r
+      val regexRemoteGitRepo = s"""git_remote: "$fakeGitRepo"""".r
 
-      assert(regexViashVersion.findFirstIn(stdout).isDefined, stdout)
-      assert(regexConfig.findFirstIn(stdout).isDefined, stdout)
-      assert(regexPlatform.findFirstIn(stdout).isDefined, stdout)
-      assert(regexExecutable.findFirstIn(stdout).isDefined, stdout)
-      assert(regexOutput.findFirstIn(stdout).isDefined, stdout)
-      assert(regexRemoteGitRepo.findFirstIn(stdout).isDefined, stdout)
+      assert(regexViashVersion.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexConfig.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexPlatform.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexExecutable.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexOutput.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexRemoteGitRepo.findFirstIn(metaStr).isDefined, stdout)
 
     }
     finally {
@@ -321,28 +331,33 @@ class MainBuildDockerSuite extends FunSuite with BeforeAndAfterAll {
         "build",
         "-p", "docker",
         "-o", tempFolStr,
-        "-m",
         configMetaFile
       )
-
+      
+      // check exec
       assert(executable.exists)
       assert(executable.canExecute)
 
+      // check meta
+      val meta = temporaryFolder.resolve(".config.vsh.yaml")
+      assert(meta.toFile.exists, meta.toString + " should exist")
+      val metaStr = scala.io.Source.fromFile(meta.toFile).getLines.mkString("\n")
+
       val viashVersion = io.viash.Main.version
 
-      val regexViashVersion = s"viash version:\\s*$viashVersion".r
-      val regexConfig = s"config:\\s*$configMetaFile".r
-      val regexPlatform = "platform:\\s*docker".r
-      val regexExecutable = s"executable:\\s*$tempFolStr/testbash".r
-      val regexOutput = s"output:\\s*$tempFolStr".r
-      val regexRemoteGitRepo = "remote git repo:\\s*<NA>".r
+      val regexViashVersion = s"""viash_version: "$viashVersion"""".r
+      val regexConfig = s"""config: "$configMetaFile"""".r
+      val regexPlatform = """platform: "docker"""".r
+      val regexExecutable = s"""executable: "$tempFolStr/testbash"""".r
+      val regexOutput = s"""output: "$tempFolStr"""".r
+      val regexRemoteGitRepo = """git_remote:"""".r
 
-      assert(regexViashVersion.findFirstIn(stdout).isDefined, stdout)
-      assert(regexConfig.findFirstIn(stdout).isDefined, stdout)
-      assert(regexPlatform.findFirstIn(stdout).isDefined, stdout)
-      assert(regexExecutable.findFirstIn(stdout).isDefined, stdout)
-      assert(regexOutput.findFirstIn(stdout).isDefined, stdout)
-      assert(regexRemoteGitRepo.findFirstIn(stdout).isDefined, stdout)
+      assert(regexViashVersion.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexConfig.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexPlatform.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexExecutable.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexOutput.findFirstIn(metaStr).isDefined, stdout)
+      assert(regexRemoteGitRepo.findFirstIn(metaStr).isEmpty, stdout)
 
     }
     finally {

--- a/src/test/scala/io/viash/MainBuildNativeSuite.scala
+++ b/src/test/scala/io/viash/MainBuildNativeSuite.scala
@@ -194,7 +194,6 @@ class MainBuildNativeSuite extends FunSuite with BeforeAndAfterAll {
     val testText = TestHelper.testMain(
       "build",
       "-o", tempFolStr,
-      "-m",
       configNoPlatformFile
     )
 
@@ -204,9 +203,6 @@ class MainBuildNativeSuite extends FunSuite with BeforeAndAfterAll {
     Exec.run(
       Seq(executable.toString, "--help")
     )
-
-    val regexPlatform = "platform:\\s*<NA>".r
-    assert(regexPlatform.findFirstIn(testText).isDefined, testText)
   }
 
   test("Test whether defining strings as arguments in argument groups throws a deprecation warning") {

--- a/src/viash/viash_build/run_test.sh
+++ b/src/viash/viash_build/run_test.sh
@@ -21,7 +21,7 @@ target_ns_add_yaml="target/native/testns/ns_add/viash.yaml"
 [[ ! -f $defaults_output ]] && echo "Default: Test output file could not be found!" && exit 1
 
 # Check if default arguments are as expected
-grep -q "viash ns build --src src --parallel --write_meta --config_mod .functionality.version := 'dev' --setup cachedbuild" $defaults_output
+grep -q "viash ns build --src src --parallel --config_mod .functionality.version := 'dev' --setup cachedbuild" $defaults_output
 
 # Check if target dir hierarchy exists
 [[ ! -d $expected_target_dir ]] && echo "Default: target directory hierarchy could not be found!" && exit 1

--- a/src/viash/viash_build/script.sh
+++ b/src/viash/viash_build/script.sh
@@ -4,7 +4,7 @@
 command_builder=(
   ns build
   --src "$par_src"
-  --parallel --write_meta
+  --parallel
 )
 
 # check par mode


### PR DESCRIPTION
* `viash build`: `--write_meta` and `--print_meta` arguments have been removed. 
  Instead, the `.config.vsh.yaml` file is always created when building Viash components.

* `viash run`: Now also creates the .config.vsh.yaml file.