### PR TITLE
add extension to tempfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@
       description: "A h5ad file"
   ```
 
+* `viash run`, `viash test`: When running or testing a component, Viash will add an extension
+  to the temporary file that is created. Before: `/tmp/viash-run-wdckjnce`, now: `/tmp/viash-run-wdckjnce.py`.
+
 ## BUG FIXES
 
 * `BashWrapper`: Don't overwrite meta values when additional arguments are provided.

--- a/src/main/scala/io/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/io/viash/wrapper/BashWrapper.scala
@@ -171,7 +171,7 @@ object BashWrapper {
         // whether it needs to be a specific path
         val scriptSetup =
           s"""
-            |tempscript=\\$$(mktemp "$$VIASH_META_TEMP_DIR/viash-run-${functionality.name}-XXXXXX.${res.companion.extension}")
+            |tempscript=\\$$(mktemp "$$VIASH_META_TEMP_DIR/viash-run-${functionality.name}-XXXXXX").${res.companion.extension}
             |function clean_up {
             |  rm "\\$$tempscript"
             |}

--- a/src/main/scala/io/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/io/viash/wrapper/BashWrapper.scala
@@ -171,7 +171,7 @@ object BashWrapper {
         // whether it needs to be a specific path
         val scriptSetup =
           s"""
-            |tempscript=\\$$(mktemp "$$VIASH_META_TEMP_DIR/viash-run-${functionality.name}-XXXXXX")
+            |tempscript=\\$$(mktemp "$$VIASH_META_TEMP_DIR/viash-run-${functionality.name}-XXXXXX.${res.companion.extension}")
             |function clean_up {
             |  rm "\\$$tempscript"
             |}


### PR DESCRIPTION
* `viash run`, `viash test`: When running or testing a component, Viash will add an extension  to the temporary file that is created. Before: `/tmp/viash-run-wdckjnce`, now: `/tmp/viash-run-wdckjnce.py`.