### PR TITLE
Use mkdir when the output is nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Viash 0.6.7
+
+## MINOR CHANGES
+
+* `NextflowPlatform`: Create directories during a stub run when output path is a nested directory.
+
 # Viash 0.6.6
 
 This release fixes an issue where stderr was being redirected to stdout.

--- a/src/main/resources/io/viash/platforms/nextflow/VDSL3Helper.nf
+++ b/src/main/resources/io/viash/platforms/nextflow/VDSL3Helper.nf
@@ -610,7 +610,7 @@ def processFactory(Map processArgs) {
   def stub = thisConfig.functionality.allArguments
     .findAll { it.type == "file" && it.direction == "output" }
     .collect { par -> 
-      "\${ args.containsKey(\"${par.plainName}\") ? \"touch \\\"\" + (args[\"${par.plainName}\"] instanceof String ? args[\"${par.plainName}\"].replace(\"_*\", \"_0\") : args[\"${par.plainName}\"].join('\" \"')) + \"\\\"\" : \"\" }"
+      "\${ args.containsKey(\"${par.plainName}\") ? \"touch2 \\\"\" + (args[\"${par.plainName}\"] instanceof String ? args[\"${par.plainName}\"].replace(\"_*\", \"_0\") : args[\"${par.plainName}\"].join('\" \"')) + \"\\\"\" : \"\" }"
     }
     .join("\n")
 
@@ -633,6 +633,7 @@ def processFactory(Map processArgs) {
   |  tuple val("\$id"), val(passthrough)$outputPaths, optional: true
   |stub:
   |\"\"\"
+  |touch2() { mkdir -p "\\\$(dirname "\\\$1")" && touch "\\\$1" ; }
   |$stub
   |\"\"\"
   |script:$assertStr


### PR DESCRIPTION
## MINOR CHANGES

* `NextflowPlatform`: Create directories during a stub run when output path is a nested directory.