### PR TITLE
Automatically split Viash config strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Viash 0.6.7
+
+## BUG FIXES
+
+* `NextflowPlatform`: Automatically split Viash config strings into strings of 
+  length 65000 since the JVM has a limit on the length of string constants (65536).
+
 # Viash 0.6.6
 
 This release fixes an issue where stderr was being redirected to stdout.

--- a/src/main/scala/io/viash/platforms/NextflowVdsl3Platform.scala
+++ b/src/main/scala/io/viash/platforms/NextflowVdsl3Platform.scala
@@ -244,6 +244,9 @@ case class NextflowVdsl3Platform(
       .replace("\\\\", "\\\\\\\\")
       .replace("\\\"", "\\\\\"")
       .replace("'''", "\\'\\'\\'")
+      .grouped(65000) // JVM has a maximum string limit of 65535
+      .toList         // see https://stackoverflow.com/a/6856773
+      .mkString("'''", "''' + '''", "'''")
     val autoJson = auto.asJson.dropEmptyRecursively
 
     /************************* MAIN.NF *************************/
@@ -263,7 +266,7 @@ case class NextflowVdsl3Platform(
       |// DEFINE CUSTOM CODE
       |
       |// functionality metadata
-      |thisConfig = processConfig(jsonSlurper.parseText('''$funJsonStr'''))
+      |thisConfig = processConfig(jsonSlurper.parseText($funJsonStr))
       |
       |thisScript = '''$executionCode'''
       |


### PR DESCRIPTION

* `NextflowPlatform`: Automatically split Viash config strings into strings of 
  length 65000 since the JVM has a limit on the length of string constants (65536).