### PR TITLE
Filter reflected classes by class type instead of searching for '=> ' tags

### DIFF
--- a/src/main/scala/io/viash/schemas/CollectedSchemas.scala
+++ b/src/main/scala/io/viash/schemas/CollectedSchemas.scala
@@ -80,13 +80,13 @@ object CollectedSchemas {
 
     val allMembers = baseClasses
       .zipWithIndex
-      .flatMap(x =>
-        x._1.info.members
+      .flatMap{ case (baseClass, index) =>
+        baseClass.info.members
           .filter(_.fullName.startsWith("io.viash"))
           .filter(m => memberNames.contains(m.shortName))
-          .filter(m => !m.info.toString.startsWith("=> ") || x._2 != 0) // Only regular members if base class, otherwise all members
-          .map(y => MemberInfo(y, (constructorMembers.contains(y.shortName)), x._1.fullName, x._2))
-      )
+           .filter(m => !m.info.getClass.toString.endsWith("NullaryMethodType") || index != 0) // Only regular members if base class, otherwise all members
+          .map(y => MemberInfo(y, (constructorMembers.contains(y.shortName)), baseClass.fullName, index))
+        }
       .groupBy(k => k.shortName)
     
     (allMembers, baseClasses)

--- a/src/main/scala/io/viash/schemas/CollectedSchemas.scala
+++ b/src/main/scala/io/viash/schemas/CollectedSchemas.scala
@@ -84,7 +84,7 @@ object CollectedSchemas {
         baseClass.info.members
           .filter(_.fullName.startsWith("io.viash"))
           .filter(m => memberNames.contains(m.shortName))
-           .filter(m => !m.info.getClass.toString.endsWith("NullaryMethodType") || index != 0) // Only regular members if base class, otherwise all members
+          .filter(m => !m.info.getClass.toString.endsWith("NullaryMethodType") || index != 0) // Only regular members if base class, otherwise all members
           .map(y => MemberInfo(y, (constructorMembers.contains(y.shortName)), baseClass.fullName, index))
         }
       .groupBy(k => k.shortName)


### PR DESCRIPTION
In Scala 2.12, the '=> ' tag was a reliable way to filter, but with Scala 2.13 this is no longer present. Filtering for "NullaryMethodType" instead gives the desired functionality now.

Improve the syntax of the mapping of a tuple and unapply to 2 names.



No changelog entry added as I consider it part of updating to Scala 2.13