### PR TITLE
Change default of --src from src/ to ./

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
     ```
   The old `get.viash.io` is still available but points to the version 0.6.7 version of this component and is deprecated.
 
+* `viash ns`: Change the default value of `--src` from `src/` to `./`. Add `src: src/` to 
+  the project config `_viash.yaml` to revert to the previous behaviour.
+
 ## MINOR CHANGES
 
 * `Main`: Capture build, setup and push errors and output an exit code.

--- a/src/main/scala/io/viash/Main.scala
+++ b/src/main/scala/io/viash/Main.scala
@@ -178,13 +178,13 @@ object Main {
         )
       case x: ViashNs with ViashNsBuild =>
         proj0.copy(
-          source = x.src.toOption orElse proj0.source orElse Some("src"),
+          source = x.src.toOption orElse proj0.source orElse Some("."),
           target = x.target.toOption orElse proj0.target orElse Some("target"),
           config_mods = proj0.config_mods ::: x.config_mods()
         )
       case x: ViashNs =>
         proj0.copy(
-          source = x.src.toOption orElse proj0.source orElse Some("src"),
+          source = x.src.toOption orElse proj0.source orElse Some("."),
           config_mods = proj0.config_mods ::: x.config_mods()
         )
       case _ => proj0


### PR DESCRIPTION
This allows Viash to pick up components that are not stored in the `src/` directory.