### PR TITLE
Add missing unit return value in testbench

### DIFF
--- a/src/test/scala/io/viash/helpers/GitTest.scala
+++ b/src/test/scala/io/viash/helpers/GitTest.scala
@@ -165,7 +165,7 @@ class GitTest extends AnyFunSuite with BeforeAndAfterAll {
     assert(Git.getTag(tempDir) == Some("0.1.1"), "Git.getTag")
   }
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     tempPaths.foreach(tempDir => IO.deleteRecursively(tempDir))
   }
 }


### PR DESCRIPTION
Minor change, add a `: Unit = `.

Considered part of the switch to Scala 2.13, so no additional changelog entry.