### PR TITLE
Pass empty multiple arguments as empty array instead of "null"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 * `viash (ns) build`: Change the default value of the namespace separator in a Docker platform from `_` to `/`. 
   Add `".platforms[.type == 'docker'].namespace_separator := '_'"` to the project config `_viash.yaml` to revert to the previous behaviour.
 
+* `bash wrapper`: In python, javascript and R scripts, parameters with multiple set to `true` but without given values now have an empty array as default instead of respectively `None`, `undefined` and `NULL`.
+
 ## MAJOR CHANGES
 
 * `VDSL3`: now uses the newly implemented `channelFromParams` and `preprocessInputs` instead of `viashChannel`.

--- a/src/main/scala/io/viash/functionality/resources/JavaScriptScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/JavaScriptScript.scala
@@ -67,7 +67,12 @@ case class JavaScriptScript(
         case _: StringArgument => s"""$env_name"""
       }
 
-      s"""'${par.plainName}': $$VIASH_DOLLAR$$( if [ ! -z $${${par.VIASH_PAR}+x} ]; then echo "$parse"; else echo undefined; fi )"""
+      val notFound = par match {
+        case a if a.multiple => "[]"
+        case _ => "undefined"
+      }
+
+      s"""'${par.plainName}': $$VIASH_DOLLAR$$( if [ ! -z $${${par.VIASH_PAR}+x} ]; then echo "$parse"; else echo $notFound; fi )"""
     }
     s"""let $dest = {
       |  ${parSet.mkString(",\n  ")}

--- a/src/main/scala/io/viash/functionality/resources/PythonScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/PythonScript.scala
@@ -67,7 +67,12 @@ case class PythonScript(
         case _: StringArgument => s"""$env_name"""
       }
 
-      s"""'${par.plainName}': $$VIASH_DOLLAR$$( if [ ! -z $${${par.VIASH_PAR}+x} ]; then echo "$parse"; else echo None; fi )"""
+      val notFound = par match {
+        case a if a.multiple => "[]"
+        case _ => "None"
+      }
+
+      s"""'${par.plainName}': $$VIASH_DOLLAR$$( if [ ! -z $${${par.VIASH_PAR}+x} ]; then echo "$parse"; else echo $notFound; fi )"""
     }
 
     s"""$dest = {

--- a/src/main/scala/io/viash/functionality/resources/RScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/RScript.scala
@@ -67,8 +67,23 @@ case class RScript(
           case _: StringArgument => ("", "")
         }
         val sl = "\\VIASH_SLASH\\" // used instead of "\\", as otherwise the slash gets escaped automatically.
+
+        val class_ = par match {
+          case _: BooleanArgumentBase => "logical"
+          case _: IntegerArgument => "integer"
+          case _: LongArgument => "bit64::integer64"
+          case _: DoubleArgument => "numeric"
+          case _: FileArgument => "character"
+          case _: StringArgument => "character"
+        }
+
+        val notFound = par match {
+          case a if a.multiple =>
+            s"\"$class_(0)\""
+          case _ => "NULL"
+        }
         
-        s""""${par.plainName}" = $$VIASH_DOLLAR$$( if [ ! -z $${${par.VIASH_PAR}+x} ]; then echo -n "$lhs'"; echo -n "$$${par.VIASH_PAR}" | sed "s#['$sl$sl]#$sl$sl$sl$sl&#g"; echo "'$rhs"; else echo NULL; fi )"""
+        s""""${par.plainName}" = $$VIASH_DOLLAR$$( if [ ! -z $${${par.VIASH_PAR}+x} ]; then echo -n "$lhs'"; echo -n "$$${par.VIASH_PAR}" | sed "s#['$sl$sl]#$sl$sl$sl$sl&#g"; echo "'$rhs"; else echo $notFound; fi )"""
       }
 
       s"""$dest <- list(

--- a/src/test/resources/testcsharp/script.csx
+++ b/src/test/resources/testcsharp/script.csx
@@ -70,8 +70,10 @@ try
         if (p.PropertyType.IsArray)
         {
             object[] array = (object[])p.GetValue(par);
-
-            Output(p.Name + ": |" + string.Join(", ", array) + "|");
+            if (array.Length == 0)
+                Output(p.Name + ": |empty array|");
+            else
+                Output(p.Name + ": |" + string.Join(", ", array) + "|");
         }
         else
         {

--- a/src/test/resources/testcsharp/test.sh
+++ b/src/test/resources/testcsharp/test.sh
@@ -59,8 +59,8 @@ grep -q 'output: ||' output2.txt
 grep -q 'log: ||' output2.txt
 grep -q 'optional: ||' output2.txt
 grep -q 'optional_with_default: |The default value.|' output2.txt
-grep -q 'multiple: ||' output2.txt
-grep -q 'multiple_pos: ||' output2.txt
+grep -q 'multiple: |empty array|' output2.txt
+grep -q 'multiple_pos: |empty array|' output2.txt
 grep -q 'resources_dir: |..*|' output2.txt
 grep -q 'meta_resources_dir: |..*|' output.txt
 grep -q 'meta_functionality_name: |testcsharp|' output.txt

--- a/src/test/resources/testjs/code.js
+++ b/src/test/resources/testjs/code.js
@@ -53,7 +53,10 @@ if (typeof par['output'] === 'undefined') {
 }
 
 for (const key in par) {
-	outFun(`${key}: |${par[key]}|`)
+	if (Array.isArray(par[key]) && par[key].length == 0)
+		outFun(`${key}: |empty array|`)
+	else
+		outFun(`${key}: |${par[key]}|`)
 }
 for (const key in meta) {
 	outFun(`meta_${key}: |${meta[key]}|`)

--- a/src/test/resources/testjs/test.sh
+++ b/src/test/resources/testjs/test.sh
@@ -60,8 +60,8 @@ grep -q 'output: |undefined|' output2.txt
 grep -q 'log: |undefined|' output2.txt
 grep -q 'optional: |undefined|' output2.txt
 grep -q 'optional_with_default: |The default value.|' output2.txt
-grep -q 'multiple: |undefined|' output2.txt
-grep -q 'multiple_pos: |undefined|' output2.txt
+grep -q 'multiple: |empty array|' output2.txt
+grep -q 'multiple_pos: |empty array|' output2.txt
 grep -q 'meta_resources_dir: |..*|' output2.txt
 grep -q 'meta_functionality_name: |testjs|' output2.txt
 grep -q 'meta_cpus: |666|' output2.txt

--- a/src/test/resources/testpython/code.py
+++ b/src/test/resources/testpython/code.py
@@ -40,8 +40,8 @@ def echo(s):
 
 try:
     for key, value in par.items():
-        if type(value) == list:
-            if len(value) == 0:
+        if isinstance(value, list):
+            if not value:
                 echo(f"{key}: |empty array|")
             else:
                 echo(f"{key}: |{','.join(value)}|")

--- a/src/test/resources/testpython/code.py
+++ b/src/test/resources/testpython/code.py
@@ -41,7 +41,10 @@ def echo(s):
 try:
     for key, value in par.items():
         if type(value) == list:
-            echo(f"{key}: |{','.join(value)}|")
+            if len(value) == 0:
+                echo(f"{key}: |empty array|")
+            else:
+                echo(f"{key}: |{','.join(value)}|")
         else:
             echo(f"{key}: |{value}|")
 

--- a/src/test/resources/testpython/test.sh
+++ b/src/test/resources/testpython/test.sh
@@ -14,6 +14,7 @@ $meta_executable "NOTICE" --real_number 10.5 --whole_number=10 -s "a string with
   --long_number 112589990684262400
 
 [[ ! -f output.txt ]] && echo "Output file could not be found!" && exit 1
+cat output.txt
 grep -q 'input: |NOTICE|' output.txt
 grep -q 'real_number: |10.5|' output.txt
 grep -q 'whole_number: |10|' output.txt
@@ -50,6 +51,7 @@ $meta_executable \
   > output2.txt
 
 [[ ! -f output2.txt ]] && echo "Output file could not be found!" && exit 1
+cat output2.txt
 grep -q 'input: |resource2.txt|' output2.txt
 grep -q 'real_number: |123.456|' output2.txt
 grep -q 'whole_number: |789|' output2.txt
@@ -60,8 +62,8 @@ grep -q 'output: |None|' output2.txt
 grep -q 'log: |None|' output2.txt
 grep -q 'optional: |None|' output2.txt
 grep -q 'optional_with_default: |The default value.|' output2.txt
-grep -q 'multiple: |None|' output2.txt
-grep -q 'multiple_pos: |None|' output2.txt
+grep -q 'multiple: |empty array|' output2.txt
+grep -q 'multiple_pos: |empty array|' output2.txt
 grep -q 'meta_resources_dir: |..*|' output2.txt
 grep -q 'meta_functionality_name: |testpython|' output2.txt
 grep -q 'meta_cpus: |666|' output2.txt

--- a/src/test/resources/testr/script.vsh.R
+++ b/src/test/resources/testr/script.vsh.R
@@ -88,7 +88,11 @@ if (length(par$output) > 0) {
 }
 
 str <- sapply(names(par), function(n) {
-  paste0(n, ": |", paste(par[[n]], collapse = ","), "|\n")
+  if(typeof(par[[n]]) == "character" && length(par[[n]]) == 0) {
+    paste0(n, ": |empty array|\n")
+  } else {
+    paste0(n, ": |", paste(par[[n]], collapse = ","), "|\n")
+  }
 })
 write_fun(par$output, str)
 

--- a/src/test/resources/testr/test.sh
+++ b/src/test/resources/testr/test.sh
@@ -60,8 +60,8 @@ grep -q 'output: ||' output2.txt
 grep -q 'log: ||' output2.txt
 grep -q 'optional: ||' output2.txt
 grep -q 'optional_with_default: |The default value.|' output2.txt
-grep -q 'multiple: ||' output2.txt
-grep -q 'multiple_pos: ||' output2.txt
+grep -q 'multiple: |empty array|' output2.txt
+grep -q 'multiple_pos: |empty array|' output2.txt
 grep -q 'meta_resources_dir: |..*|' output2.txt
 grep -q 'meta_functionality_name: |testr|' output2.txt
 grep -q 'meta_cpus: |666|' output2.txt


### PR DESCRIPTION
In python, javascript and R scripts, parameters with multiple set to `true` but without given values now have an empty array as default instead of respectively `None`, `undefined` and `NULL`.