### PR TITLE
Simplify tag during testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@
   - Add 2 testbenches for computational requirements when running `viash run` or `viash test`.
   - Added tests for different values for the `--id` and `--param_list` parameters of VDSL3 modules.
 
+* `viash test`: Use `test` as a random tag during testing, instead of `test` plus a random string.
+
 ## BUG FIXES
 
 * `WorkflowHelper`: fixed where passing a relative path as `-param_list` would cause incorrect resolving of input files.

--- a/src/main/scala/io/viash/ViashTest.scala
+++ b/src/main/scala/io/viash/ViashTest.scala
@@ -62,7 +62,7 @@ object ViashTest {
     keepFiles: Option[Boolean] = None,
     quiet: Boolean = false,
     setupStrategy: String = "cachedbuild",
-    tempVersion: Boolean = true,
+    tempVersion: Option[String] = Some("test"),
     verbosityLevel: Int = 6,
     parentTempPath: Option[Path] = None, 
     cpus: Option[Int], 
@@ -73,15 +73,16 @@ object ViashTest {
     if (!quiet) println(s"Running tests in temporary directory: '$dir'")
 
     // set version to temporary value
-    val config2 = if (tempVersion) {
-      config.copy(
-        functionality = config.functionality.copy(
-          version = Some("test_" + Random.alphanumeric.take(6).mkString)
+    val config2 = 
+      if (tempVersion.isDefined) {
+        config.copy(
+          functionality = config.functionality.copy(
+            version = tempVersion
+          )
         )
-      )
-    } else {
-      config
-    }
+      } else {
+        config
+      }
 
     // run tests
     val ManyTestOutput(setupRes, results) = ViashTest.runTests(


### PR DESCRIPTION
* Use `test` as a random tag during testing, instead of `test` plus a random string.