### PR TITLE
fix indexedseq warnings

### DIFF
--- a/src/main/scala/io/viash/Main.scala
+++ b/src/main/scala/io/viash/Main.scala
@@ -172,7 +172,7 @@ object Main {
     }
 
     // parse arguments
-    val cli = new CLIConf(viashArgs) 
+    val cli = new CLIConf(viashArgs.toIndexedSeq) 
     
     // see if there are project overrides passed to the viash command
     val proj1 = cli.subcommands.last match {
@@ -201,7 +201,7 @@ object Main {
         ViashRun(
           config = config,
           platform = platform.get, 
-          args = runArgs.dropWhile(_ == "--"), 
+          args = runArgs.toIndexedSeq.dropWhile(_ == "--"), 
           keepFiles = cli.run.keep.toOption.map(_.toBoolean),
           cpus = cli.run.cpus.toOption,
           memory = cli.run.memory.toOption

--- a/src/main/scala/io/viash/helpers/Format.scala
+++ b/src/main/scala/io/viash/helpers/Format.scala
@@ -31,7 +31,7 @@ object Format {
   }
 
   def paragraphWrap(s: String, n: Int): Seq[String] = {
-    s.split("\n").flatMap(t => Format.wordWrap(t, n))
+    s.split("\n").toIndexedSeq.flatMap(t => Format.wordWrap(t, n))
   }
 }
 


### PR DESCRIPTION
Fix fixes warnings like:

```
[warn] src/main/scala/io/viash/helpers/Format.scala:34:26: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
[warn]     s.split("\n").flatMap(t => Format.wordWrap(t, n))
[warn]                          ^
```