### PR TITLE
`viash config view`: Resource parent paths should be directories and not file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 TODO add summary
 
+## BUG FIXES
+
+* `viash config view`: Resource parent paths should be directories and not file (#398).
+
 # Viash 0.7.2 (2023-04-17): Project-relative paths and improved metadata handling
 
 This update adds functionality to resolve paths starting with a slash as relative to the project directory, improves handling of info metadata in the config, and fixes to the operator precedence of config mods.
@@ -15,7 +19,7 @@ This update adds functionality to resolve paths starting with a slash as relativ
 
 ## MINOR CHANGES
 
-* `config yaml`: Do not modify (e.g. strip empty fields) of the `.functionality.info` and `.functionality.arguments[].info` fields (#386).
+* `viash config view`: Do not modify (e.g. strip empty fields) of the `.functionality.info` and `.functionality.arguments[].info` fields (#386).
 
 ## BUG FIXES
 

--- a/src/main/scala/io/viash/config/Config.scala
+++ b/src/main/scala/io/viash/config/Config.scala
@@ -216,10 +216,10 @@ object Config {
     // convert Json into Config
     val conf0 = json2.as[Config].fold(parsingErrorHandler, identity)
 
-    /* CONFIG 1: make resources absolute */
-    // make paths absolute
-    val resources = conf0.functionality.resources.map(_.copyWithAbsolutePath(uri, projectDir))
-    val tests = conf0.functionality.test_resources.map(_.copyWithAbsolutePath(uri, projectDir))
+    /* CONFIG 1: store parent path in resource to be able to access them in the future */
+    val parentURI = uri.resolve("")
+    val resources = conf0.functionality.resources.map(_.copyWithAbsolutePath(parentURI, projectDir))
+    val tests = conf0.functionality.test_resources.map(_.copyWithAbsolutePath(parentURI, projectDir))
 
     // copy resources with updated paths into config and return
     val conf1 = conf0.copy(


### PR DESCRIPTION
## Describe your changes

`viash config view`: Resource parent paths should be directories and not files.

## Issue ticket number and link
Closes #397

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] Relevant unit tests have been added