### PR TITLE
Viash 0.7.3 (2023-04-19): Minor bug fixes in documentation and config view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ TODO add summary
 
 ## BUG FIXES
 
-* `DockerPlatform`: Fixed example in documentation for the `namespace_separator` parameter.
+* `DockerPlatform`: Fixed example in documentation for the `namespace_separator` parameter (#396).
+
+* `viash config view`: Resource parent paths should be directories and not file (#398).
 
 # Viash 0.7.2 (2023-04-17): Project-relative paths and improved metadata handling
 
@@ -19,7 +21,7 @@ This update adds functionality to resolve paths starting with a slash as relativ
 
 ## MINOR CHANGES
 
-* `config yaml`: Do not modify (e.g. strip empty fields) of the `.functionality.info` and `.functionality.arguments[].info` fields (#386).
+* `viash config view`: Do not modify (e.g. strip empty fields) of the `.functionality.info` and `.functionality.arguments[].info` fields (#386).
 
 ## BUG FIXES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Viash 0.7.3 (yyyy-MM-dd): TODO Add title
+
+TODO add summary
+
 # Viash 0.7.2 (2023-04-17): Project-relative paths and improved metadata handling
 
 This update adds functionality to resolve paths starting with a slash as relative to the project directory, improves handling of info metadata in the config, and fixes to the operator precedence of config mods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
-# Viash 0.7.3 (yyyy-MM-dd): TODO Add title
+# Viash 0.7.3 (2023-04-19): Minor bug fixes in documentation and config view
 
-TODO add summary
+Fix minor issues in the documentation and with the way parent paths of resources are printed a config view.
 
 ## BUG FIXES
 
 * `DockerPlatform`: Fixed example in documentation for the `namespace_separator` parameter (#396).
 
 * `viash config view`: Resource parent paths should be directories and not file (#398).
+
 
 # Viash 0.7.2 (2023-04-17): Project-relative paths and improved metadata handling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 TODO add summary
 
+## BUG FIXES
+
+* `DockerPlatform`: Fixed example in documentation for the `namespace_separator` parameter.
+
 # Viash 0.7.2 (2023-04-17): Project-relative paths and improved metadata handling
 
 This update adds functionality to resolve paths starting with a slash as relative to the project directory, improves handling of info metadata in the config, and fixes to the operator precedence of config mods.

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -1,0 +1,62 @@
+# Prepare the develop branch for release
+
+## Set the version in `build.sbt`
+
+e.g. from `version := "0.7.2 dev"` to `version := "0.7.2"`
+
+## Finalize the changelog changes
+
+- Set the correct version number
+- Set the current date
+- Provide a title
+- Add a summary
+
+## Create a PR from develop to main
+
+# Merge PR to main
+
+## Add a tag on main with the new version number
+
+# Create GitHub release
+
+Title: 'Viash 0.7.2'
+Content: Add the full changelog entry of this release
+
+# Build viash and viash_install and add to the release
+
+Create the binaries with `make && make tools`.
+Add the files `bin/viash` and `bin/viash_install`.
+
+# Update the website
+
+The source repository is [here](https://github.com/viash-io/website).
+Follow the information in the README.md to get up and running if needed.
+
+## Rerender Website
+
+Short summary if you already have an operational envirionment:
+
+```bash
+./_src/render_pages.sh 
+```
+
+(This script already contains the environment switch command (`source renv/python/virtualenvs/renv-python-3.10/bin/activate`))
+
+## Create a new branch, push to GitHub and create a PR to main
+
+## Merge website PR
+
+# Post merge
+
+Under the `develop` branch,
+- Update the version in `build.sbt` to the next version with a `dev` suffix.
+- Add a placeholder entry in `CHANGELOG.md` for a future release.
+
+Template:
+
+```
+# Viash 0.x.x (yyyy-MM-dd): TODO Add title
+
+TODO add summary
+```
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "viash"
 
-version := "0.7.3 dev"
+version := "0.7.3"
 
 scalaVersion := "2.13.10"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "viash"
 
-version := "0.7.2"
+version := "0.7.3 dev"
 
 scalaVersion := "2.13.10"
 

--- a/src/main/scala/io/viash/config/Config.scala
+++ b/src/main/scala/io/viash/config/Config.scala
@@ -216,10 +216,10 @@ object Config {
     // convert Json into Config
     val conf0 = json2.as[Config].fold(parsingErrorHandler, identity)
 
-    /* CONFIG 1: make resources absolute */
-    // make paths absolute
-    val resources = conf0.functionality.resources.map(_.copyWithAbsolutePath(uri, projectDir))
-    val tests = conf0.functionality.test_resources.map(_.copyWithAbsolutePath(uri, projectDir))
+    /* CONFIG 1: store parent path in resource to be able to access them in the future */
+    val parentURI = uri.resolve("")
+    val resources = conf0.functionality.resources.map(_.copyWithAbsolutePath(parentURI, projectDir))
+    val tests = conf0.functionality.test_resources.map(_.copyWithAbsolutePath(parentURI, projectDir))
 
     // copy resources with updated paths into config and return
     val conf1 = conf0.copy(

--- a/src/main/scala/io/viash/platforms/DockerPlatform.scala
+++ b/src/main/scala/io/viash/platforms/DockerPlatform.scala
@@ -73,11 +73,11 @@ case class DockerPlatform(
   @example("target_tag: 0.5.0", "yaml")
   target_tag: Option[String] = None,
 
-  @description("The separator between the namespace and the name of the component, used for determining the image name.")
-  @example("namespace_separator: \"+\"", "yaml")
+  @description("The separator between the namespace and the name of the component, used for determining the image name. Default: `\"/\"`.")
+  @example("namespace_separator: \"_\"", "yaml")
   namespace_separator: String = "/",
 
-  @description("Enables or disables automatic volume mapping. Enabled when set to `Automatic` or disabled when set to `Manual`. Default: `Automatic`")
+  @description("Enables or disables automatic volume mapping. Enabled when set to `Automatic` or disabled when set to `Manual`. Default: `Automatic`.")
   resolve_volume: DockerResolveVolume = Automatic,
 
   @description("In Linux, files created by a Docker container will be owned by `root`. With `chown: true`, Viash will automatically change the ownership of output files (arguments with `type: file` and `direction: output`) to the user running the Viash command after execution of the component. Default value: `true`.")


### PR DESCRIPTION

Fix minor issues in the documentation and with the way parent paths of resources are printed a config view.

## BUG FIXES

* `DockerPlatform`: Fixed example in documentation for the `namespace_separator` parameter (#396).

* `viash config view`: Resource parent paths should be directories and not file (#398).
