### PR TITLE
VDSL3Platform & WorkflowHelper: Fix passing remote file uri to 'param_list'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Viash 0.7.4 (yyyy-MM-dd): TODO Add title
 
-TODO add summary
+## BUG FIXES
+
+* `WorkflowHelper`: Fixed an issue where passing a remote file URI (for example `http://` or `s3://`) as `param_list` caused `No such file` errors.
 
 # Viash 0.7.3 (2023-04-19): Minor bug fixes in documentation and config view
 

--- a/src/main/resources/io/viash/platforms/nextflow/WorkflowHelper.nf
+++ b/src/main/resources/io/viash/platforms/nextflow/WorkflowHelper.nf
@@ -31,9 +31,9 @@ def getChild(parent, child) {
   }
 }
 
-def readCsv(file) {
+def readCsv(file_path) {
   def output = []
-  def inputFile = file !instanceof File ? new File(file) : file
+  def inputFile = file_path !instanceof File ? file(file_path) : file_path
 
   // todo: allow escaped quotes in string
   // todo: allow single quotes?
@@ -87,8 +87,8 @@ def readJsonBlob(str) {
   jsonSlurper.parseText(str)
 }
 
-def readJson(file) {
-  def inputFile = file !instanceof File ? new File(file) : file
+def readJson(file_path) {
+  def inputFile = file_path !instanceof File ? file(file_path) : file_path
   def jsonSlurper = new JsonSlurper()
   jsonSlurper.parse(inputFile)
 }
@@ -98,8 +98,8 @@ def readYamlBlob(str) {
   yamlSlurper.load(str)
 }
 
-def readYaml(file) {
-  def inputFile = file !instanceof File ? new File(file) : file
+def readYaml(file_path) {
+  def inputFile = file_path !instanceof File ? file(file_path) : file_path
   def yamlSlurper = new Yaml()
   yamlSlurper.load(inputFile)
 }

--- a/src/main/resources/io/viash/platforms/nextflow/WorkflowHelper.nf
+++ b/src/main/resources/io/viash/platforms/nextflow/WorkflowHelper.nf
@@ -33,14 +33,14 @@ def getChild(parent, child) {
 
 def readCsv(file_path) {
   def output = []
-  def inputFile = file_path !instanceof File ? file(file_path) : file_path
+  def inputFile = file_path !instanceof Path ? file(file_path) : file_path
 
   // todo: allow escaped quotes in string
   // todo: allow single quotes?
   def splitRegex = Pattern.compile(''',(?=(?:[^"]*"[^"]*")*[^"]*$)''')
   def removeQuote = Pattern.compile('''"(.*)"''')
 
-  def br = new BufferedReader(new FileReader(inputFile))
+  def br = new BufferedReader(new FileReader(inputFile.toFile()))
 
   def row = -1
   def header = null
@@ -88,7 +88,7 @@ def readJsonBlob(str) {
 }
 
 def readJson(file_path) {
-  def inputFile = file_path !instanceof File ? file(file_path) : file_path
+  def inputFile = file_path !instanceof Path ? file(file_path) : file_path
   def jsonSlurper = new JsonSlurper()
   jsonSlurper.parse(inputFile)
 }
@@ -99,7 +99,7 @@ def readYamlBlob(str) {
 }
 
 def readYaml(file_path) {
-  def inputFile = file_path !instanceof File ? file(file_path) : file_path
+  def inputFile = file_path !instanceof Path ? file(file_path) : file_path
   def yamlSlurper = new Yaml()
   yamlSlurper.load(inputFile)
 }


### PR DESCRIPTION
## Describe your changes

This fixes an issue where a remote file URI would not be correctly wrapped around nextflow's file functionality when passed to `param_list`, causing this remote to not be downloaded. The effect is that the file was searched for on the local file system, raising `File not found:` errors.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - ~[ ] Breaking changes~
  - ~[ ] New functionality~
  - ~[ ] Major changes~
  - ~[ ] Minor changes~
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] Relevant unit tests have been added