### PR TITLE
Move relativizing dependency paths to Dependency class

### DIFF
--- a/src/main/scala/io/viash/functionality/dependencies/Dependency.scala
+++ b/src/main/scala/io/viash/functionality/dependencies/Dependency.scala
@@ -109,7 +109,17 @@ case class Dependency(
 
 object Dependency {
 
-  // Relativize the writtenPath info from a dependency to a source and destination path so it can be copied.
+  /**
+    * Relativize the writtenPath info from a dependency to a source and destination path so it can be copied.
+    * 
+    * This method is somewhat of a stopgap solution as this and the 'getRelativePath' functions in the case class and companion object should be revised.
+    *
+    * @param dependencyPath Path of the dependency as they are found in .config.vsh.yaml, relative to the original build location
+    * @param output Output / target path as root for where the build artifacts should be located
+    * @param repoPath Path of the repository where the dependency is found
+    * @param mainDependency Top level dependency for which optionally dependencies of dependencies are being resolved. Used to relativize paths
+    * @return Tuple with source and destination paths, relativized to current repository locations, ready to be copied
+    */
   def getSourceAndDestinationFromWrittenPath(dependencyPath: String, output: Path, repoPath: Path, mainDependency: Dependency): (Path, Path) = {
     import scala.jdk.CollectionConverters._
 

--- a/src/main/scala/io/viash/helpers/DependencyResolver.scala
+++ b/src/main/scala/io/viash/helpers/DependencyResolver.scala
@@ -253,7 +253,7 @@ object DependencyResolver {
     // this returns paths relative to `repoPath` of dependencies to be copied to `output`
     val dependencyPaths = getSparseDependencyInfo(builtDependencyPath + "/.config.vsh.yaml")
 
-    for(dp <- dependencyPaths) {
+    for (dp <- dependencyPaths) {
       // Get the source & destination path for the dependency, functionality depends whether it was a previous dependency or not.
       // Paths are relativized depending the original dependency.
       val (sourcePath, destPath) = Dependency.getSourceAndDestinationFromWrittenPath(dp, output, repoPath, dependency)


### PR DESCRIPTION
Functionality is roughly the same but moved away from the DependencyResolver copy function and moved to Dependency.

## Describe your changes

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] Relevant unit tests have been added