### PR TITLE
Remove the `entrypoint` parameter for all script types except `Nextfl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 TODO add summary
 
+## MINOR CHANGES
+
+* `Scripts`: Remove the `entrypoint` parameter for all script types except `NextflowScript`. All these scripts had to check individually whether the parameter was unset, now it can be done in the `Script` apply method. (#409)
+
 # Viash 0.7.3 (2023-04-19): Minor bug fixes in documentation and config view
 
 Fix minor issues in the documentation and with the way parent paths of resources are printed a config view.

--- a/src/main/scala/io/viash/functionality/resources/BashScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/BashScript.scala
@@ -35,14 +35,9 @@ case class BashScript(
   is_executable: Option[Boolean] = Some(true),
   parent: Option[URI] = None,
 
-  @undocumented
-  entrypoint: Option[String] = None,
-
   @description("Specifies the resource as a Bash script.")
   `type`: String = BashScript.`type`
 ) extends Script {
-  assert(entrypoint.isEmpty, message = s"Entrypoints are not (yet) supported for resources of type ${`type`}.")
-
   val companion = BashScript
   def copyResource(path: Option[String], text: Option[String], dest: Option[String], is_executable: Option[Boolean], parent: Option[URI]): Resource = {
     copy(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)

--- a/src/main/scala/io/viash/functionality/resources/CSharpScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/CSharpScript.scala
@@ -35,13 +35,9 @@ case class CSharpScript(
   is_executable: Option[Boolean] = Some(true),
   parent: Option[URI] = None,
 
-  @undocumented
-  entrypoint: Option[String] = None,
-
   @description("Specifies the resource as a C# script.")
   `type`: String = CSharpScript.`type`
 ) extends Script {
-  assert(entrypoint.isEmpty, message = s"Entrypoints are not (yet) supported for resources of type ${`type`}.")
   val companion = CSharpScript
   def copyResource(path: Option[String], text: Option[String], dest: Option[String], is_executable: Option[Boolean], parent: Option[URI]): Resource = {
     copy(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)

--- a/src/main/scala/io/viash/functionality/resources/Executable.scala
+++ b/src/main/scala/io/viash/functionality/resources/Executable.scala
@@ -32,14 +32,9 @@ case class Executable(
   is_executable: Option[Boolean] = Some(true),
   parent: Option[URI] = None,
 
-  @undocumented
-  entrypoint: Option[String] = None,
-
   @description("Specifies the resource as an executable.")
   `type`: String = "executable"
 ) extends Script {
-  assert(entrypoint.isEmpty, message = s"Entrypoints are not (yet) supported for resources of type ${`type`}.")
-
   val companion = Executable
   def copyResource(path: Option[String], text: Option[String], dest: Option[String], is_executable: Option[Boolean], parent: Option[URI]): Resource = {
     copy(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)

--- a/src/main/scala/io/viash/functionality/resources/JavaScriptScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/JavaScriptScript.scala
@@ -35,14 +35,9 @@ case class JavaScriptScript(
   is_executable: Option[Boolean] = Some(true),
   parent: Option[URI] = None,
 
-  @undocumented
-  entrypoint: Option[String] = None,
-
   @description("Specifies the resource as a JavaScript script.")
   `type`: String = JavaScriptScript.`type`
 ) extends Script {
-  assert(entrypoint.isEmpty, message = s"Entrypoints are not (yet) supported for resources of type ${`type`}.")
-  
   val companion = JavaScriptScript
   def copyResource(path: Option[String], text: Option[String], dest: Option[String], is_executable: Option[Boolean], parent: Option[URI]): Resource = {
     copy(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)

--- a/src/main/scala/io/viash/functionality/resources/PythonScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/PythonScript.scala
@@ -35,14 +35,9 @@ case class PythonScript(
   is_executable: Option[Boolean] = Some(true),
   parent: Option[URI] = None,
 
-  @undocumented
-  entrypoint: Option[String] = None,
-
   @description("Specifies the resource as a Python script.")
   `type`: String = PythonScript.`type`
 ) extends Script {
-  assert(entrypoint.isEmpty, message = s"Entrypoints are not (yet) supported for resources of type ${`type`}.")
-  
   val companion = PythonScript
   def copyResource(path: Option[String], text: Option[String], dest: Option[String], is_executable: Option[Boolean], parent: Option[URI]): Resource = {
     copy(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)

--- a/src/main/scala/io/viash/functionality/resources/RScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/RScript.scala
@@ -35,14 +35,9 @@ case class RScript(
   is_executable: Option[Boolean] = Some(true),
   parent: Option[URI] = None,
 
-  @undocumented
-  entrypoint: Option[String] = None,
-
   @description("Specifies the resource as a R script.")
   `type`: String = RScript.`type`
 ) extends Script {
-  assert(entrypoint.isEmpty, message = s"Entrypoints are not (yet) supported for resources of type ${`type`}.")
-  
   val companion = RScript
   def copyResource(path: Option[String], text: Option[String], dest: Option[String], is_executable: Option[Boolean], parent: Option[URI]): Resource = {
     copy(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)

--- a/src/main/scala/io/viash/functionality/resources/ScalaScript.scala
+++ b/src/main/scala/io/viash/functionality/resources/ScalaScript.scala
@@ -35,14 +35,9 @@ case class ScalaScript(
   is_executable: Option[Boolean] = Some(true),
   parent: Option[URI] = None,
 
-  @undocumented
-  entrypoint: Option[String] = None,
-
   @description("Specifies the resource as a Scala script.")
   `type`: String = ScalaScript.`type`
 ) extends Script {
-  assert(entrypoint.isEmpty, message = s"Entrypoints are not (yet) supported for resources of type ${`type`}.")
-  
   val companion = ScalaScript
   def copyResource(path: Option[String], text: Option[String], dest: Option[String], is_executable: Option[Boolean], parent: Option[URI]): Resource = {
     copy(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)

--- a/src/main/scala/io/viash/functionality/resources/Script.scala
+++ b/src/main/scala/io/viash/functionality/resources/Script.scala
@@ -105,21 +105,25 @@ object Script {
     entrypoint: Option[String] = None,
     `type`: String
   ): Script = {
+
+    if (`type` != NextflowScript.`type`)
+      assert(entrypoint.isEmpty, message = s"Entrypoints are not (yet) supported for resources of type ${`type`}.")
+
     `type` match {
       case BashScript.`type` =>
-        BashScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent, entrypoint = entrypoint)
+        BashScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)
       case CSharpScript.`type` =>
-        CSharpScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent, entrypoint = entrypoint)
+        CSharpScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)
       case JavaScriptScript.`type` =>
-        JavaScriptScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent, entrypoint = entrypoint)
+        JavaScriptScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)
       case NextflowScript.`type` =>
         NextflowScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent, entrypoint = entrypoint)
       case PythonScript.`type` =>
-        PythonScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent, entrypoint = entrypoint)
+        PythonScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)
       case RScript.`type` =>
-        RScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent, entrypoint = entrypoint)
+        RScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)
       case ScalaScript.`type` =>
-        ScalaScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent, entrypoint = entrypoint)
+        ScalaScript(path = path, text = text, dest = dest, is_executable = is_executable, parent = parent)
     }
   }
 }


### PR DESCRIPTION
…owScript`.

All these scripts had to check individually whether the parameter was unset, now it can be done in the `Script` apply method.

## Describe your changes

## Issue ticket number and link
Closes #409

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] Relevant unit tests have been added