### PR TITLE
Create a .build.yaml in the target folder if it doesn't exist

### DIFF
--- a/src/main/scala/io/viash/functionality/dependencies/Repository.scala
+++ b/src/main/scala/io/viash/functionality/dependencies/Repository.scala
@@ -23,6 +23,7 @@ import java.nio.file.Paths
 import io.viash.schemas._
 import java.nio.file.Path
 import java.io.File
+import java.nio.file.Files
 
 @description("Specifies a repository where dependency components can be found.")
 abstract class Repository {
@@ -68,7 +69,14 @@ object Repository {
     repo match {
       case r: GithubRepository => {
         val r2 = r.checkoutSparse()
-        r2.checkout()
+        val r3 = r2.checkout()
+        // Stopgap solution to be able to use built repositories which were not built with dependency aware Viash version.
+        // TODO remove this section once it's deemed no longer necessary
+        if (Paths.get(r3.localPath, "target").toFile().exists() && !Paths.get(r3.localPath, "target", ".build.yaml").toFile().exists()) {
+          Console.err.println(s"${Console.YELLOW}Creating temporary 'target/.build.yaml' file for ${r3.name} as this file seems to be missing.${Console.RESET}")
+          Files.createFile(Paths.get(r3.localPath, "target", ".build.yaml"))
+        }
+        r3
       }
       case r: LocalRepository if r.path.isDefined => {
         val localPath = r.path.get match {


### PR DESCRIPTION
## Describe your changes

Assume that if the folder `target` exists but the `.build.yaml` is missing it must be due the repository was built with a non-dependency viash version.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Bug fixes

~- [ ] Proposed changes are described in the CHANGELOG.md~

~- [ ] Relevant unit tests have been added~