### PR TITLE
Fix escaping BashWrapper pipe characters being stripped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ TODO add summary
 
 * `viash config inject`: Fix an empty line being added at the script start for each time `viash config inject` was run (#377).
 
+* `BashWrapper`: Fix escaping of the included script where a line starting with a pipe character with optional leading spaces is stripped of the leading spaces and pipe character.
+  This was quite unlikely to happen except when `viash config inject` was called on a Nextflow Script, which lead to no real config code being injected however workflows were getting corrupted. (#421)
+
 # Viash 0.7.3 (2023-04-19): Minor bug fixes in documentation and config view
 
 Fix minor issues in the documentation and with the way parent paths of resources are printed a config view.

--- a/src/main/scala/io/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/io/viash/wrapper/BashWrapper.scala
@@ -117,8 +117,10 @@ object BashWrapper {
     mods: BashWrapperMods = BashWrapperMods(),
     debugPath: Option[String] = None
   ): String = {
-    // escape substrings with pipe characters, meant to be used when using stripMargin
-    def escapePipes(s: String) = s.split("\n").map(_.replaceFirst("^(\\s*\\|)", "|$1")).mkString("\n")
+    // Escape substrings with pipe characters, meant to be used when using stripMargin.
+    // If the very first substring also starts with a pipe, strip the escaping off again as it will either become part of a previous string
+    // or would have its own | from the multiline string, and we don't want double pipes.
+    def escapePipes(s: String) = s.split("\n").map(_.replaceFirst("^(\\s*\\|)", "|$1")).mkString("\n").stripPrefix("|")
 
     val mainResource = functionality.mainScript
 

--- a/src/main/scala/io/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/io/viash/wrapper/BashWrapper.scala
@@ -117,6 +117,9 @@ object BashWrapper {
     mods: BashWrapperMods = BashWrapperMods(),
     debugPath: Option[String] = None
   ): String = {
+    // escape substrings with pipe characters, meant to be used when using stripMargin
+    def escapePipes(s: String) = s.split("\n").map(_.replaceFirst("^(\\s*\\|)", "|$1")).mkString("\n")
+
     val mainResource = functionality.mainScript
 
     // check whether the wd needs to be set to the resources dir
@@ -158,7 +161,7 @@ object BashWrapper {
         s"""
           |set -e
           |cat > "${debugPath.get}" << 'VIASHMAIN'
-          |$escapedCode
+          |${escapePipes(escapedCode)}
           |VIASHMAIN
           |""".stripMargin
 
@@ -186,7 +189,7 @@ object BashWrapper {
         s"""
           |set -e$scriptSetup
           |cat > "$scriptPath" << 'VIASHMAIN'
-          |$escapedCode
+          |${escapePipes(escapedCode)}
           |VIASHMAIN$cdToResources
           |${res.command(scriptPath)} &
           |wait "\\$$!"
@@ -290,7 +293,7 @@ object BashWrapper {
        |eval set -- $$VIASH_POSITIONAL_ARGS
        |${spaceCode(allMods.postParse)}${spaceCode(allMods.preRun)}
        |ViashDebug "Running command: ${executor.replaceAll("^eval (.*)", "\\$(echo $1)")}"
-       |$heredocStart$executor$executionCode$heredocEnd
+       |$heredocStart$executor${escapePipes(executionCode)}$heredocEnd
        |${spaceCode(allMods.postRun)}${spaceCode(allMods.last)}
        |
        |exit 0

--- a/src/main/scala/io/viash/wrapper/BashWrapper.scala
+++ b/src/main/scala/io/viash/wrapper/BashWrapper.scala
@@ -117,10 +117,8 @@ object BashWrapper {
     mods: BashWrapperMods = BashWrapperMods(),
     debugPath: Option[String] = None
   ): String = {
-    // Escape substrings with pipe characters, meant to be used when using stripMargin.
-    // If the very first substring also starts with a pipe, strip the escaping off again as it will either become part of a previous string
-    // or would have its own | from the multiline string, and we don't want double pipes.
-    def escapePipes(s: String) = s.split("\n").map(_.replaceFirst("^(\\s*\\|)", "|$1")).mkString("\n").stripPrefix("|")
+    // Add pipes after each newline. Prevents pipes being stripped when a string starts with a pipe (with optional leading spaces).
+    def escapePipes(s: String) = s.replaceAll("\n", "\n|")
 
     val mainResource = functionality.mainScript
 


### PR DESCRIPTION
## Describe your changes

Fix escaping BashWrapper pipe characters being stripped

Fix escaping of the included script where a line starting with a pipe character with optional leading spaces is stripped of the leading spaces and pipe character.

Add a function that escapes pipe characters (with leading spaces) and use where stripMargin is called on the script.

## Issue ticket number and link
Closes #421 

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] Relevant unit tests have been added