### PR TITLE
Change GithubRepository to generic GitRepository

### DIFF
--- a/src/main/scala/io/viash/functionality/dependencies/package.scala
+++ b/src/main/scala/io/viash/functionality/dependencies/package.scala
@@ -27,13 +27,13 @@ package object dependencies {
 
   // encoders and decoders for Argument
   implicit val encodeDependency: Encoder.AsObject[Dependency] = deriveConfiguredEncoder
-  implicit val encodeGithubRepository: Encoder.AsObject[GithubRepository] = deriveConfiguredEncoder
+  implicit val encodeGitRepository: Encoder.AsObject[GitRepository] = deriveConfiguredEncoder
   implicit val encodeLocalRepository: Encoder.AsObject[LocalRepository] = deriveConfiguredEncoder
   implicit def encodeRepository[A <: Repository]: Encoder[A] = Encoder.instance {
     par =>
       val typeJson = Json.obj("type" -> Json.fromString(par.`type`))
       val objJson = par match {
-        case s: GithubRepository => encodeGithubRepository(s)
+        case s: GitRepository => encodeGitRepository(s)
         case s: LocalRepository => encodeLocalRepository(s)
       }
       objJson deepMerge typeJson
@@ -41,13 +41,14 @@ package object dependencies {
 
 
   implicit val decodeDependency: Decoder[Dependency] = deriveConfiguredDecoder
-  implicit val decodeGithubRepository: Decoder[GithubRepository] = deriveConfiguredDecoder
+  implicit val decodeGitRepository: Decoder[GitRepository] = deriveConfiguredDecoder
   implicit val decodeLocalRepository: Decoder[LocalRepository] = deriveConfiguredDecoder
   implicit def decodeRepository: Decoder[Repository] = Decoder.instance {
     cursor =>
       val decoder: Decoder[Repository] =
         cursor.downField("type").as[String] match {
-          case Right("github") => decodeGithubRepository.widen
+          case Right("github") => decodeGitRepository.widen
+          case Right("git") => decodeGitRepository.widen
           case Right("local") => decodeLocalRepository.widen
           case Right(typ) => throw new RuntimeException("Type " + typ + " is not recognised. Valid types are github, ..., ... and local.")
           case Left(exception) => throw exception

--- a/src/main/scala/io/viash/helpers/DependencyResolver.scala
+++ b/src/main/scala/io/viash/helpers/DependencyResolver.scala
@@ -23,7 +23,7 @@ import io.viash.config.Config
 import io.viash.lenses.ConfigLenses._
 import io.viash.lenses.FunctionalityLenses._
 import io.viash.lenses.RepositoryLens._
-import io.viash.functionality.dependencies.GithubRepository
+import io.viash.functionality.dependencies.GitRepository
 import java.nio.file.Files
 import java.io.IOException
 import java.io.UncheckedIOException


### PR DESCRIPTION
Match `github` and `git` to GitRepository
Change the fullUri depending on the git type
Add ssh:// to the git repo type. Should we always do this?

## Describe your changes

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [x] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Bug fixes

~- [ ] Proposed changes are described in the CHANGELOG.md~

~- [ ] Relevant unit tests have been added~