### PR TITLE
Implement an override map for sys.env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * `viash ns build`: Fix the error summary when a setup or push failure occurs. These conditions were not displayed and could cause confusion (PR #447).
 
+* `testbench`: Fix the viash version switch test bench not working for newer Java versions (PR #).
+
 # Viash 0.7.4 (2023-05-31): Minor bug fixes and minor improvements to VDSL3
 
 Some small fixes and consistency improvements.

--- a/src/main/scala/io/viash/Main.scala
+++ b/src/main/scala/io/viash/Main.scala
@@ -45,6 +45,8 @@ object Main {
   val version: String = if (pkg.getImplementationVersion != null) pkg.getImplementationVersion else "test"
 
   val viashHome = Paths.get(sys.env.getOrElse("VIASH_HOME", sys.env("HOME") + "/.viash"))
+  val sysEnvOverride = scala.collection.mutable.Map.empty[String, String]
+  def sysEnvGet(key: String): Option[String] = sysEnvOverride.get(key) orElse sys.env.get(key)
 
   /**
     * Viash main
@@ -456,8 +458,8 @@ object Main {
     */
   def detectVersion(workingDir: Option[Path]): Option[String] = {
     // if VIASH_VERSION is defined, use that
-    if (sys.env.get("VIASH_VERSION").isDefined) {
-      sys.env.get("VIASH_VERSION")
+    if (sysEnvGet("VIASH_VERSION").isDefined) {
+      sysEnvGet("VIASH_VERSION")
     } else {
       // else look for project file in working dir
       // and try to read as json

--- a/src/test/scala/io/viash/auxiliary/MainRunVersionSwitch.scala
+++ b/src/test/scala/io/viash/auxiliary/MainRunVersionSwitch.scala
@@ -32,10 +32,7 @@ class MainRunVersionSwitch extends AnyFunSuite with BeforeAndAfterAll {
   override def afterAll(): Unit = System.setSecurityManager(null)
 
   def setEnv(key: String, value: String) = {
-    val field = System.getenv().getClass.getDeclaredField("m")
-    field.setAccessible(true)
-    val map = field.get(System.getenv()).asInstanceOf[java.util.Map[java.lang.String, java.lang.String]]
-    map.put(key, value)
+    Main.sysEnvOverride.addOne(key -> value)
   }
 
   test("Verify VIASH_VERSION is undefined by default", NativeTest) {
@@ -66,7 +63,7 @@ class MainRunVersionSwitch extends AnyFunSuite with BeforeAndAfterAll {
 
     setEnv("VIASH_VERSION", "0.6.6")
 
-    val version = sys.env.get("VIASH_VERSION")
+    val version = Main.sysEnvGet("VIASH_VERSION")
     assert(version == Some("0.6.6"))
 
     val arguments = Seq("--version")
@@ -89,7 +86,7 @@ class MainRunVersionSwitch extends AnyFunSuite with BeforeAndAfterAll {
 
     setEnv("VIASH_VERSION", "-")
 
-    val version = sys.env.get("VIASH_VERSION")
+    val version = Main.sysEnvGet("VIASH_VERSION")
     assert(version == Some("-"))
 
     val arguments = Seq("--version")
@@ -118,7 +115,7 @@ class MainRunVersionSwitch extends AnyFunSuite with BeforeAndAfterAll {
 
     setEnv("VIASH_VERSION", "invalid")
 
-    val version = sys.env.get("VIASH_VERSION")
+    val version = Main.sysEnvGet("VIASH_VERSION")
     assert(version == Some("invalid"))
 
     val arguments = Seq("--version")


### PR DESCRIPTION
Don't try to hack into the sys.env. This is now blocked in newer Java versions. Instead add an empty map and helper method that is checked. When the map doesn't have the key, get it from sys.env.

## Describe your changes

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] Relevant unit tests have been added