### PR TITLE
Feature/logger colorize level parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 * `help message`: Print the relevant help message of (sub-)command when `--help` is given as an argument instead of only printing the help message when it is the leading argument and otherwise silently disregarding it (PR #472). This overrides Scallop's default behaviour in a roundabout way.
 
-* `Logging`: Add a Logger helper class (PR #485). Allows manually enabling or disabling colorizing TTY output by using `--colorize`. Add provisions for adding debugging or trace code which is not outputted by default. Changing logging level can be changed with `--loglevel`. These CLI arguments are currently hidden.
+* `Logging`: Add a Logger helper class (PR #485 & #490). Allows manually enabling or disabling colorizing TTY output by using `--colorize`. Add provisions for adding debugging or trace code which is not outputted by default. Changing logging level can be changed with `--loglevel`. These CLI arguments are currently hidden.
 
 ## MINOR CHANGES
 

--- a/src/test/scala/io/viash/helpers/LoggerTest.scala
+++ b/src/test/scala/io/viash/helpers/LoggerTest.scala
@@ -3,6 +3,8 @@ package io.viash.helpers
 import org.scalatest.funsuite.AnyFunSuite
 import java.io.ByteArrayOutputStream
 import scala.io.AnsiColor
+import io.viash.TestHelper
+import java.io.FileNotFoundException
 
 class LoggerTest extends AnyFunSuite {
   Logger.UseColorOverride.value = Some(false)
@@ -350,6 +352,71 @@ class LoggerTest extends AnyFunSuite {
 
     assert(stdout2 == expectOut2)
     assert(stderr2 == expectErr2)
+  }
+
+  // We can't really test the colorize or loglevel options as the singletons would need to be recreated.
+  // However we can verify that the parsing happened correctly and set the inner logger values correctly.
+
+  test("Check without --colorize option") {
+    Logger.UseColorOverride.value = Some(false)
+    TestHelper.testMainException[FileNotFoundException](
+      "config", "view", "missing.vsh.yaml",
+    )
+    assert(Logger.UseColorOverride.value == Some(false))
+
+    Logger.UseColorOverride.value = Some(true)
+    TestHelper.testMainException[FileNotFoundException](
+      "config", "view", "missing.vsh.yaml",
+    )
+    assert(Logger.UseColorOverride.value == Some(true))
+
+    Logger.UseColorOverride.value = Some(false)
+  }
+
+  test("Check --colorize true option") {
+    TestHelper.testMainException[FileNotFoundException](
+      "config", "view", "missing.vsh.yaml",
+      "--colorize", "true"
+    )
+    assert(Logger.UseColorOverride.value == Some(true))
+    Logger.UseColorOverride.value = Some(false)
+  }
+
+  test("Check --colorize false option") {
+    TestHelper.testMainException[FileNotFoundException](
+      "config", "view", "missing.vsh.yaml",
+      "--colorize", "false"
+    )
+    assert(Logger.UseColorOverride.value == Some(false))
+    Logger.UseColorOverride.value = Some(false)
+  }
+
+  test("Check --colorize auto option") {
+    TestHelper.testMainException[FileNotFoundException](
+      "config", "view", "missing.vsh.yaml",
+      "--colorize", "auto"
+    )
+    assert(Logger.UseColorOverride.value == None)
+    Logger.UseColorOverride.value = Some(false)
+  }
+
+  test("Check --loglevel debug") {
+    assert(Logger.UseLevelOverride.value == LoggerLevel.Info)
+    TestHelper.testMainException[FileNotFoundException](
+      "config", "view", "missing.vsh.yaml",
+      "--loglevel", "debug"
+    )
+    assert(Logger.UseLevelOverride.value == LoggerLevel.Debug)
+    Logger.UseLevelOverride.value = LoggerLevel.Info
+  }
+
+  test("Check without --loglevel set") {
+    assert(Logger.UseLevelOverride.value == LoggerLevel.Info)
+    TestHelper.testMainException[FileNotFoundException](
+      "config", "view", "missing.vsh.yaml",
+    )
+    assert(Logger.UseLevelOverride.value == LoggerLevel.Info)
+    Logger.UseLevelOverride.value = LoggerLevel.Info
   }
 
 }


### PR DESCRIPTION
## Describe your changes

Attempt to test CLI --colorize and --loglevel

To evaluate whether this causes issues with other tests as they are parallelized.

We can't really test the colorize or loglevel options as the singletons would need to be recreated.
However we can verify that the parsing happened correctly and set the inner logger values correctly.

## Issue ticket number and link
~Closes #xxxx (Replace xxxx with the GitHub issue number)~

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] Relevant unit tests have been added