### PR TITLE
Update scallop to 5.0.0 and apply new functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 * `viash export cli_autocomplete`: Export a Bash or Zsh autocomplete script (PR #465 & #482).
 
-* `help message`: Print the relevant help message of (sub-)command when `--help` is given as an argument instead of only printing the help message when it is the leading argument and otherwise silently disregarding it (PR #472). This overrides Scallop's default behaviour in a roundabout way.
+* `help message`: Print the relevant help message of (sub-)command when `--help` is given as an argument instead of only printing the help message when it is the leading argument and otherwise silently disregarding it (PR #...). This is a new feature implemented in Scallop 5.0.0.
 
 * `Logging`: Add a Logger helper class (PR #485 & #490). Allows manually enabling or disabling colorizing TTY output by using `--colorize`. Add provisions for adding debugging or trace code which is not outputted by default. Changing logging level can be changed with `--loglevel`. These CLI arguments are currently hidden.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 * `viash export cli_autocomplete`: Export a Bash or Zsh autocomplete script (PR #465 & #482).
 
-* `help message`: Print the relevant help message of (sub-)command when `--help` is given as an argument instead of only printing the help message when it is the leading argument and otherwise silently disregarding it (PR #...). This is a new feature implemented in Scallop 5.0.0.
+* `help message`: Print the relevant help message of (sub-)command when `--help` is given as an argument instead of only printing the help message when it is the leading argument and otherwise silently disregarding it (initially added in PR #472, replaced by PR #496). This is a new feature implemented in Scallop 5.0.0.
 
 * `Logging`: Add a Logger helper class (PR #485 & #490). Allows manually enabling or disabling colorizing TTY output by using `--colorize`. Add provisions for adding debugging or trace code which is not outputted by default. Changing logging level can be changed with `--loglevel`. These CLI arguments are currently hidden.
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ scalaVersion := "2.13.10"
 libraryDependencies ++= Seq(
   "org.scalactic" %% "scalactic" % "3.2.15" % "test",
   "org.scalatest" %% "scalatest" % "3.2.15" % "test",
-  "org.rogach" %% "scallop" % "4.1.0",
+  "org.rogach" %% "scallop" % "5.0.0",
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1",
   "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"

--- a/src/test/scala/io/viash/e2e/help/MainHelpSuite.scala
+++ b/src/test/scala/io/viash/e2e/help/MainHelpSuite.scala
@@ -20,16 +20,15 @@ class MainHelpSuite extends AnyFunSuite{
     assert(stdout.contains("testbash"))
   }
 
-  // We still can't test this properly as Scallop just exits hard
-  // test("viash config view default functionality leading help") {
-  //   val res = TestHelper.testMainException2[ExitException](
-  //     "config", "view",
-  //     "--help"
-  //   )
+  test("viash config view default functionality leading help") {
+    val output = TestHelper.testMainException[ExitException](
+      "config", "view",
+      "--help"
+    )
 
-  //   assert(res.output.startsWith("viash config view"))
-  //   assert(!res.output.contains("testbash"))
-  // }
+    assert(output.startsWith("viash config view"))
+    assert(!output.contains("testbash"))
+  }
 
   test("viash config view default functionality trailing help") {
     val output = TestHelper.testMainException[ExitException](


### PR DESCRIPTION
Remove reflection code for trailing --help as it is now supported by Scallop Add --help testbench as it now doesn't croak the whole test

## Describe your changes

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] Relevant unit tests have been added