### PR TITLE
Use `moduleDir` instead of `projectDir` to determine the resource directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ TODO add summary
 
 * `NextflowPlatform`: Throw error when unexpected keys are passed to the `.run()` method (#512, PR #518).
 
+* `NextflowPlatform`: Use `moduleDir` instead of `projectDir` to determine the resource directory.
+
 ## DOCUMENTATION
 
 * Minor fixes to VDSL3 reference documentation (PR #508).

--- a/src/main/resources/io/viash/platforms/nextflow/WorkflowHelper.nf
+++ b/src/main/resources/io/viash/platforms/nextflow/WorkflowHelper.nf
@@ -1339,7 +1339,7 @@ def _findBuildYamlFile(path) {
 
 // get the root of the target folder
 def getRootDir() {
-  def dir = _findBuildYamlFile(projectDir.toAbsolutePath())
+  def dir = _findBuildYamlFile(moduleDir.normalize())
   assert dir != null: "Could not find .build.yaml in the folder structure"
   dir.getParent()
 }

--- a/src/main/resources/io/viash/platforms/nextflow/functions/getRootDir.nf
+++ b/src/main/resources/io/viash/platforms/nextflow/functions/getRootDir.nf
@@ -16,7 +16,7 @@ def _findBuildYamlFile(path) {
 
 // get the root of the target folder
 def getRootDir() {
-  def dir = _findBuildYamlFile(projectDir.toAbsolutePath())
+  def dir = _findBuildYamlFile(moduleDir.normalize())
   assert dir != null: "Could not find .build.yaml in the folder structure"
   dir.getParent()
 }

--- a/src/main/scala/io/viash/platforms/NextflowPlatform.scala
+++ b/src/main/scala/io/viash/platforms/NextflowPlatform.scala
@@ -252,7 +252,7 @@ case class NextflowPlatform(
       |// START COMPONENT-SPECIFIC CODE
       |
       |// retrieve resourcesDir here to make sure the correct path is found
-      |resourcesDir = nextflow.script.ScriptMeta.current().getScriptPath().getParent()
+      |resourcesDir = moduleDir.normalize()
       |
       |// component metadata
       |thisConfig = ${NextflowHelper.generateConfigStr(config)}

--- a/src/main/scala/io/viash/platforms/nextflow/NextflowHelper.scala
+++ b/src/main/scala/io/viash/platforms/nextflow/NextflowHelper.scala
@@ -197,7 +197,7 @@ object NextflowHelper {
         // can we use suboutputpath here?
         //val dependencyPath = Paths.get(dependency.subOutputPath.get)
         val relativePath = parentPath.relativize(dependencyPath)
-        s"\"$$projectDir/$relativePath\""
+        s"\"$$resourcesDir/$relativePath\""
       } else {
         s"\"$$rootDir/dependencies/${dependency.subOutputPath.get}/main.nf\""
       }


### PR DESCRIPTION
## Describe your changes

Use `moduleDir` instead of `projectDir` to determine the resource directory.

This seems to produce exactly the same results as the previously used approach, namely: `resourcesDir = nextflow.script.ScriptMeta.current().getScriptPath().getParent()`.

Contents of `src/main.nf`:

```groovy
include { src2 } from "../src2/main.nf"

resourcesDir = nextflow.script.ScriptMeta.current().getScriptPath().getParent()

workflow {
  def prefix = "src"

  println()
  println("${prefix} - projectDir:               ${projectDir}")
  println("${prefix} - baseDir:                  ${baseDir}")
  println("${prefix} - launchDir:                ${launchDir}")
  println("${prefix} - moduleDir:                ${moduleDir}")
  println("${prefix} - moduleDir.normalize():    ${moduleDir.normalize()}")
  println("${prefix} - resourcesDir.normalize(): ${resourcesDir.normalize()}")
  println("${prefix} - baseDir:                  ${baseDir}")
  // println("${prefix} - workDir: ${workDir}")
  // println("${prefix} - workflow: ${workflow}")
  // println("${prefix} - nextflow: ${nextflow}")
  println()

  src2()
}
```

Contents of `src2/main.nf`:

```groovy
resourcesDir = nextflow.script.ScriptMeta.current().getScriptPath().getParent()

workflow src2 {
  def prefix = "src2"
  
  println()
  println("${prefix} - projectDir:               ${projectDir}")
  println("${prefix} - baseDir:                  ${baseDir}")
  println("${prefix} - launchDir:                ${launchDir}")
  println("${prefix} - moduleDir:                ${moduleDir}")
  println("${prefix} - moduleDir.normalize():    ${moduleDir.normalize()}")
  println("${prefix} - resourcesDir.normalize(): ${resourcesDir.normalize()}")
  println("${prefix} - baseDir:                  ${baseDir}")
  // println("${prefix} - workDir: ${workDir}")
  // println("${prefix} - workflow: ${workflow}")
  // println("${prefix} - nextflow: ${nextflow}")
  println()
}
```

Output:

    $ nextflow run src/main.nf
    N E X T F L O W  ~  version 22.10.4
    Launching `src/main.nf` [nasty_plateau] DSL2 - revision: 5b0c1fdb6e
    
    src - projectDir:               /home/rcannood/workspace/viash-io/testnextflowvdsl3/src
    src - baseDir:                  /home/rcannood/workspace/viash-io/testnextflowvdsl3/src
    src - launchDir:                /home/rcannood/workspace/viash-io/testnextflowvdsl3
    src - moduleDir:                /home/rcannood/workspace/viash-io/testnextflowvdsl3/src
    src - moduleDir.normalize():    /home/rcannood/workspace/viash-io/testnextflowvdsl3/src
    src - resourcesDir.normalize(): /home/rcannood/workspace/viash-io/testnextflowvdsl3/src
    src - baseDir:                  /home/rcannood/workspace/viash-io/testnextflowvdsl3/src
    
    
    src2 - projectDir:               /home/rcannood/workspace/viash-io/testnextflowvdsl3/src
    src2 - baseDir:                  /home/rcannood/workspace/viash-io/testnextflowvdsl3/src
    src2 - launchDir:                /home/rcannood/workspace/viash-io/testnextflowvdsl3
    src2 - moduleDir:                /home/rcannood/workspace/viash-io/testnextflowvdsl3/src/../src2
    src2 - moduleDir.normalize():    /home/rcannood/workspace/viash-io/testnextflowvdsl3/src2
    src2 - resourcesDir.normalize(): /home/rcannood/workspace/viash-io/testnextflowvdsl3/src2
    src2 - baseDir:                  /home/rcannood/workspace/viash-io/testnextflowvdsl3/src


## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [ ] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [ ] Relevant unit tests have been added