### PR TITLE
Fix using .run() without `fromState` defined an an input channel of tuples with more than two elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 TODO add summary
 
+## BUG FIXES
+
+* `NextflowPlatform`: Fix `Invalid method invocation 'call'` error when using `.run()` without `fromState` defined and the input channel holds tuples with more than two elements (PR #587). This issue also impacts some other helper functionality like `runEach()`. 
+
 # Viash 0.8.0 (2023-10-23): Nextflow workflows and dependencies
 
 Nextflow workflows definitions are picked up by Viash and assembled into a functional Nextflow workflow, reducing the amount of boilerplate code needed to be written by the user.

--- a/src/main/resources/io/viash/platforms/nextflow/workflowFactory/workflowFactory.nf
+++ b/src/main/resources/io/viash/platforms/nextflow/workflowFactory/workflowFactory.nf
@@ -120,7 +120,7 @@ def workflowFactory(Map args, Map defaultWfArgs, Map meta) {
         def new_data = workflowArgs.fromState(it.take(2))
         [it[0], new_data]
       } :
-      chRun
+      chRun | map {tup -> tup.take(2)}
 
     // fill in defaults
     chArgsWithDefaults = chArgs

--- a/src/test/resources/testnextflowvdsl3/src/test_wfs/nested/main.nf
+++ b/src/test/resources/testnextflowvdsl3/src/test_wfs/nested/main.nf
@@ -9,10 +9,9 @@ workflow base {
       file = tempFile()
       file.write("num: $num")
 
-      ["num$num", [ num: num, file: file ]]
+      ["num$num", [ file: file ], ["extra": "foo!"]]
     }
     | sub_workflow.run(
-      fromState: ["file": "file"],
       toState: {id, output, state -> 
         def newState = [
           "step1_output": output.output, 
@@ -22,6 +21,7 @@ workflow base {
         return newState
       }
     )
+    | map {tup -> [tup[0], tup[1]]}
     | view{ id, state ->
       def num = state.num
 

--- a/src/test/resources/testnextflowvdsl3/src/test_wfs/nested/main.nf
+++ b/src/test/resources/testnextflowvdsl3/src/test_wfs/nested/main.nf
@@ -9,7 +9,7 @@ workflow base {
       file = tempFile()
       file.write("num: $num")
 
-      ["num$num", [ file: file ], ["extra": "foo!"]]
+      ["num$num", [ file: file ], ["num": num]]
     }
     | sub_workflow.run(
       toState: {id, output, state -> 
@@ -21,9 +21,8 @@ workflow base {
         return newState
       }
     )
-    | map {tup -> [tup[0], tup[1]]}
-    | view{ id, state ->
-      def num = state.num
+    | view{ id, state, extra ->
+      def num = extra.num
 
       // check id
       assert id == "num$num": "id should be 'num$num'. Found: '$id'"


### PR DESCRIPTION
## Describe your changes

Fix using .run() with no `fromState` defined with an input channel of tuples with more than two elements.

## Issue ticket number and link
Closes #586 (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] Relevant unit tests have been added