### PR TITLE
Develop 0 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-# Viash 0.x.x (yyyy-MM-dd): TODO Add title
+# Viash 0.8.1 (2023-11-20): Minor bug fix to Nextflow workflows
 
-TODO add summary
+This release fixes a bug in the Nextflow platform where calling a workflow with the `.run()` function without specifying the `fromState` argument would result in an error when the input channel contained tuples with more than two elements.
 
 ## BUG FIXES
 
-* `NextflowPlatform`: Fix `Invalid method invocation 'call'` error when using `.run()` without `fromState` defined and the input channel holds tuples with more than two elements (PR #587). This issue also impacts some other helper functionality like `runEach()`. 
+ `NextflowPlatform`: Fix error when using `.run()` without using `fromState` and the input channel holds tuples with more than two elements (PR #587).
 
 # Viash 0.8.0 (2023-10-23): Nextflow workflows and dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Viash 0.x.x (yyyy-MM-dd): TODO Add title
+
+TODO add summary
+
 # Viash 0.8.0 (2023-10-23): Nextflow workflows and dependencies
 
 Nextflow workflows definitions are picked up by Viash and assembled into a functional Nextflow workflow, reducing the amount of boilerplate code needed to be written by the user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 TODO add summary
 
+## BUG FIXES
+
+* `NextflowPlatform`: Fix `Invalid method invocation 'call'` error when using `.run()` without `fromState` defined and the input channel holds tuples with more than two elements (PR #587). This issue also impacts some other helper functionality like `runEach()`. 
+
 # Viash 0.8.0 (2023-10-23): Nextflow workflows and dependencies
 
 Nextflow workflows definitions are picked up by Viash and assembled into a functional Nextflow workflow, reducing the amount of boilerplate code needed to be written by the user.

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "viash"
 
-version := "0.8.1dev"
+version := "0.8.1"
 
 scalaVersion := "2.13.10"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "viash"
 
-version := "0.8.0"
+version := "0.8.1dev"
 
 scalaVersion := "2.13.10"
 

--- a/src/main/resources/io/viash/platforms/nextflow/workflowFactory/workflowFactory.nf
+++ b/src/main/resources/io/viash/platforms/nextflow/workflowFactory/workflowFactory.nf
@@ -120,7 +120,7 @@ def workflowFactory(Map args, Map defaultWfArgs, Map meta) {
         def new_data = workflowArgs.fromState(it.take(2))
         [it[0], new_data]
       } :
-      chRun
+      chRun | map {tup -> tup.take(2)}
 
     // fill in defaults
     chArgsWithDefaults = chArgs

--- a/src/test/resources/testnextflowvdsl3/src/test_wfs/nested/main.nf
+++ b/src/test/resources/testnextflowvdsl3/src/test_wfs/nested/main.nf
@@ -9,10 +9,9 @@ workflow base {
       file = tempFile()
       file.write("num: $num")
 
-      ["num$num", [ num: num, file: file ]]
+      ["num$num", [ file: file ], ["num": num]]
     }
     | sub_workflow.run(
-      fromState: ["file": "file"],
       toState: {id, output, state -> 
         def newState = [
           "step1_output": output.output, 
@@ -22,8 +21,8 @@ workflow base {
         return newState
       }
     )
-    | view{ id, state ->
-      def num = state.num
+    | view{ id, state, extra ->
+      def num = extra.num
 
       // check id
       assert id == "num$num": "id should be 'num$num'. Found: '$id'"


### PR DESCRIPTION
## Describe your changes

This release fixes a bug in the Nextflow platform where calling a workflow with the `.run()` function without specifying the `fromState` argument would result in an error when the input channel contained tuples with more than two elements.

## Issue ticket number and link
Closes #xxxx (Replace xxxx with the GitHub issue number)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] Relevant unit tests have been added