### PR TITLE
use "local" to match the repository name instead of using that in the sugar syntax regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ TODO add summary
 
 * `config`: Fix the main level of a component config not enforcing strict mode and instead allowing any field to be specified (PR #585).
 
+* `dependencies`: Allow the user to define a local dependency with specifying `repository: local` as sugar syntax (PR #609). A local repository is the default value so it's not required to be filled in, but allowing it with a sensible sugar syntax makes sense.
+
 # Viash 0.8.1 (2023-11-20): Minor bug fix to Nextflow workflows
 
 This release fixes a bug in the Nextflow platform where calling a workflow with the `.run()` function without specifying the `fromState` argument would result in an error when the input channel contained tuples with more than two elements.

--- a/src/main/scala/io/viash/functionality/dependencies/Repository.scala
+++ b/src/main/scala/io/viash/functionality/dependencies/Repository.scala
@@ -83,7 +83,7 @@ object Repository {
           repo = repo,
           tag = getGitTag(tag)
         ))
-      case sugarSyntaxRegex("local", repo, tag) =>
+      case "local" =>
         Some(LocalRepository("TODO generate name"))
       case _ => None
     }

--- a/src/main/scala/io/viash/functionality/dependencies/Repository.scala
+++ b/src/main/scala/io/viash/functionality/dependencies/Repository.scala
@@ -83,6 +83,12 @@ object Repository {
           repo = repo,
           tag = getGitTag(tag)
         ))
+      case sugarSyntaxRegex("local", path, tag) =>
+        Some(LocalRepository(
+          "TODO generate name",
+          path = Some(path),
+          tag = getGitTag(tag)
+        ))
       case "local" =>
         Some(LocalRepository("TODO generate name"))
       case _ => None

--- a/src/test/resources/testnextflowvdsl3/src/wf/config.vsh.yaml
+++ b/src/test/resources/testnextflowvdsl3/src/wf/config.vsh.yaml
@@ -30,7 +30,7 @@ functionality:
   dependencies:
     - name: step1 # local is implicit
     - name: step2
-      # repository: local # TODO: this should also work
+      repository: local
     - name: step3
       repository: mylocal
   repositories:

--- a/src/test/scala/io/viash/functionality/dependencies/Repository.scala
+++ b/src/test/scala/io/viash/functionality/dependencies/Repository.scala
@@ -36,6 +36,12 @@ class RepositoryTest extends AnyFunSuite {
     assert(repo.get.isInstanceOf[LocalRepository])
   }
 
+  test("Repository.unapply: handles local dependency syntax") {
+    val repo = Repository.unapply("local")
+    assert(repo.isDefined)
+    assert(repo.get.isInstanceOf[LocalRepository])
+  }
+
   test("Repository.unapply: returns None for unrecognized syntax") {
     val repo = Repository.unapply("unknown://foo.bar")
     assert(repo.isEmpty)


### PR DESCRIPTION
## Describe your changes

regex was needed to extract repo and tag names, but this is irrelevant here. It would have required something like `local://...` notation.


## Issue ticket number and link
Closes #608 

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] Relevant unit tests have been added