### PR TITLE
add test for checking whether viash produces a helpful error message when no arguments are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ TODO add summary
 * `NextflowPlatform`: properly resolve paths when a nextflow workflow has another nextflow
   workflow as dependency and the worktree contains a directory that is a symlink (PR #614).
 
+* `Main`: Fixes a bug added by #294 which causes Viash to print a stacktrace instead of a helpful error message when `viash` is run without any arguments (#617, PR #618).
+  Thanks @mberacochea for pointing out this oversight!
+
 # Viash 0.8.2 (2023-12-14): Minor changes and bug fixes
 
 This release fixes a few bugs regarding dependencies and how the Nextflow platform handles Paths.

--- a/src/main/scala/io/viash/Main.scala
+++ b/src/main/scala/io/viash/Main.scala
@@ -181,8 +181,8 @@ object Main extends Logging {
     val cli = new CLIConf(viashArgs.toIndexedSeq) 
 
     // Set Logger paramters
-    cli.subcommands.last match {
-      case x: ViashLogger => 
+    cli.subcommands.lastOption match {
+      case Some(x: ViashLogger) => 
         if (x.colorize.isDefined) {
           val colorize = x.colorize() match {
             case "auto" => None
@@ -198,17 +198,17 @@ object Main extends Logging {
     }
     
     // see if there are project overrides passed to the viash command
-    val projSrc = cli.subcommands.last match {
-      case x: ViashNs => x.src.toOption
+    val projSrc = cli.subcommands.lastOption match {
+      case Some(x: ViashNs) => x.src.toOption
       case _ => None
     }
-    val projTarg = cli.subcommands.last match {
-      case x: ViashNsBuild => x.target.toOption
+    val projTarg = cli.subcommands.lastOption match {
+      case Some(x: ViashNsBuild) => x.target.toOption
       case _ => None
     }
-    val projCm = cli.subcommands.last match {
-      case x: ViashNs => x.config_mods()
-      case x: ViashCommand => x.config_mods()
+    val projCm = cli.subcommands.lastOption match {
+      case Some(x: ViashNs) => x.config_mods()
+      case Some(x: ViashCommand) => x.config_mods()
       case _ => Nil
     }
 
@@ -371,7 +371,7 @@ object Main extends Logging {
         )
         0
       case _ =>
-        info("No subcommand was specified. See `viash --help` for more information.")
+        error("Error: No subcommand was specified. See `viash --help` for more information.")
         1
     }
   }

--- a/src/test/scala/io/viash/e2e/no_commands/MainNoArgumentsSuite.scala
+++ b/src/test/scala/io/viash/e2e/no_commands/MainNoArgumentsSuite.scala
@@ -1,0 +1,19 @@
+package io.viash.e2e.no_commands
+
+import io.viash._
+import io.viash.helpers.Logger
+import org.scalatest.funsuite.AnyFunSuite
+import io.viash.exceptions.ExitException
+
+class MainNoArgumentsSuite extends AnyFunSuite{
+  Logger.UseColorOverride.value = Some(false)
+  // path to namespace components
+  private val configFile = getClass.getResource(s"/testbash/config.vsh.yaml").getPath
+
+  test("viash without arguments produces helpful error message") {
+    val (stdout, stderr, exitCode) = TestHelper.testMainWithStdErr()
+
+    assert(exitCode > 0)
+    assert(stderr.contains("Error: No subcommand was specified. See `viash --help` for more information."))
+  }
+}


### PR DESCRIPTION
## Describe your changes

* Fixes a bug added by #294 which causes Viash to print a stacktrace instead of a helpful error message when `viash` is run without any arguments.

Observed behaviour:

```
$ viash 
Unexpected error occurred! If you think this is a bug, please post
create an issue at https://github.com/viash-io/viash/issues containing
a reproducible example and the stack trace below.

viash - 0.7.1
Stacktrace:
java.util.NoSuchElementException: last of empty list
	at scala.collection.immutable.Nil$.last(List.scala:665)
	at scala.collection.immutable.Nil$.last(List.scala:661)
	at io.viash.Main$.mainCLI(Main.scala:178)
	at io.viash.Main$.mainCLIOrVersioned(Main.scala:117)
	at io.viash.Main$.main(Main.scala:64)
	at io.viash.Main.main(Main.scala)
```

Expected behaviour:

```
$viash
Error: No subcommand was specified. See `viash --help` for more information.
```

* Adds a test to check whether Viash does indeed produce the expected error message


## Related issue(s)

<!-- Replace xxxx with the GitHub issue number. -->

Closes #617

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [ ] Minor change (non-breaking change which does not modify existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [x] I have performed a self-review of my code by checking the "Changed Files" tab.
- [x] My code follows the code style of this project.

Tests:

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

Documentation:

- [x] Proposed changes are described in the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.

## Test Environment

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test environment.
-->

