### PR TITLE
Anonymize config output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ TODO add summary
 
 * `__merge__`: Handle invalid yaml during merging (PR #570). There was not enough error handling during this operation. Switched to the more advanced `Convert.textToJson` helper method.
 
+* `config`: Anonymize paths in the config when outputting the config (PR #625).
+
 # Viash 0.8.4 (2024-01-15): Bug fix
 
 Fix building components with dependencies that have symlinks in their paths.

--- a/src/main/scala/io/viash/config/Config.scala
+++ b/src/main/scala/io/viash/config/Config.scala
@@ -87,7 +87,10 @@ case class Config(
   engines: List[Engine] = Nil,
 
   @undocumented
-  info: Option[Info] = None
+  info: Option[Info] = None,
+
+  @internalFunctionality
+  projectDir: Option[String] = None,
 ) {
 
   @description(
@@ -305,7 +308,8 @@ object Config extends Logging {
       functionality = conf0.functionality.copy(
         resources = resources,
         test_resources = tests
-      )
+      ),
+      projectDir = projectDir.map(_.toString.replaceAll("^file:/+", "/"))
     )
 
     /* CONFIG 3: add info */

--- a/src/main/scala/io/viash/config/ConfigMeta.scala
+++ b/src/main/scala/io/viash/config/ConfigMeta.scala
@@ -26,6 +26,7 @@ import io.viash.helpers.circe._
 import io.circe.Json
 import io.circe.JsonObject
 import io.viash.functionality.resources.NextflowScript
+import io.viash.helpers.IO
 
 object ConfigMeta {
   // create a yaml printer for writing the viash.yaml file
@@ -46,9 +47,9 @@ object ConfigMeta {
         val path = Paths.get(dir)
         config.copy(
           info = config.info.map(info => info.copy(
-            config = path.relativize(Paths.get(info.config)).toString(),
-            output = info.output.map(o => path.relativize(Paths.get(o)).toString()),
-            executable = info.executable.map(e => path.relativize(Paths.get(e)).toString())
+            config = IO.anonymizePath(dir, info.config),
+            output = info.output.map(o => IO.anonymizePath(dir, o)),
+            executable = info.executable.map(e => IO.anonymizePath(dir, e))
           ))
         )
       case None => config

--- a/src/main/scala/io/viash/helpers/IO.scala
+++ b/src/main/scala/io/viash/helpers/IO.scala
@@ -341,13 +341,17 @@ object IO extends Logging {
     */
   def anonymizePath(basePath: Option[Path], path: String): String = {    
     val pathPath = Paths.get(path)
-    val relative = basePath.map(_.relativize(pathPath).toString())
 
-    relative match {
-      case Some(rel) if rel.startsWith("..") => Paths.get("[anonymized]", pathPath.toFile().getName()).toString()
-      case Some(rel) => rel
-      case None if pathPath.isAbsolute => Paths.get("[anonymized]", pathPath.toFile().getName()).toString()
-      case None => path
+    if (pathPath.isAbsolute()) {
+      val relative = basePath.map(_.relativize(pathPath).toString())
+
+      relative match {
+        case Some(rel) if rel.startsWith("..") => Paths.get("[anonymized]", pathPath.toFile().getName()).toString()
+        case Some(rel) => rel
+        case None => Paths.get("[anonymized]", pathPath.toFile().getName()).toString()
+      }
+    } else {
+      path
     }
   }
 }

--- a/src/main/scala/io/viash/helpers/IO.scala
+++ b/src/main/scala/io/viash/helpers/IO.scala
@@ -345,7 +345,7 @@ object IO extends Logging {
     val relative = rootPath.relativize(pathPath).toString()
     
     if (relative.startsWith("..")) {
-      path
+      Paths.get("[anonymized]", pathPath.toFile().getName()).toString()
     } else {
       relative
     }

--- a/src/main/scala/io/viash/helpers/IO.scala
+++ b/src/main/scala/io/viash/helpers/IO.scala
@@ -329,4 +329,25 @@ object IO extends Logging {
     val newPath = resolvePathWrtURI(path, uri)
     uri.resolve(newPath)
   }
+
+  /**
+    * Relativize a path w.r.t. a base path
+    * 
+    * If the path is not relative to the base path, the path is returned unchanged
+    *
+    * @param basePath The base path of the project
+    * @param path The path to relativize
+    * @return A relativized path or the original path if it was not relative to the base path
+    */
+  def anonymizePath(basePath: String, path: String): String = {
+    val rootPath = Paths.get(basePath)
+    val pathPath = Paths.get(path)
+    val relative = rootPath.relativize(pathPath).toString()
+    
+    if (relative.startsWith("..")) {
+      path
+    } else {
+      relative
+    }
+  }
 }

--- a/src/main/scala/io/viash/project/ProjectConfig.scala
+++ b/src/main/scala/io/viash/project/ProjectConfig.scala
@@ -30,15 +30,18 @@ import io.viash.functionality.Author
 
 @description("A Viash project configuration file. It's name should be `_viash.yaml`.")
 @example(
-  """viash_version: 0.6.4
-    §source: src
-    §target: target
-    §config_mods: |
-    §  .engines[.type == 'docker'].target_registry := 'ghcr.io'
-    §  .engines[.type == 'docker'].target_organization := 'viash-io'
-    §  .engines[.type == 'docker'].namespace_separator := '/'
-    §  .engines[.type == 'docker'].target_image_source := 'https://github.com/viash-io/viash'
-    §""".stripMargin('§'), "yaml"
+  """viash_version: 0.9.0
+    |source: src
+    |target: target
+    |version: 1.0
+    |organization: viash-io
+    |links:
+    |  repository: 'https://github.com/viash-io/viash'
+    |  docker_registry: 'ghcr.io'
+    |config_mods: |
+    |  .runners[.type == 'nextflow'].directives.tag := '$id'
+    |  .runners[.type == 'nextflow'].config.script := 'includeConfig("configs/custom.config")'
+    |""".stripMargin, "yaml"
 )
 @since("Viash 0.6.4")
 @nameOverride("Project")

--- a/src/main/scala/io/viash/project/ProjectConfigLinks.scala
+++ b/src/main/scala/io/viash/project/ProjectConfigLinks.scala
@@ -20,6 +20,13 @@ package io.viash.project
 import io.viash.schemas._
 
 @description("Links to external resources related to the project.")
+@example(
+  """repository: "https://github.com/viash-io/viash"
+    |docker_registry: "https://ghcr.io"
+    |homepage: "https://viash.io"
+    |documentation: "https://viash.io/reference/"
+    |issue_tracker: "https://github.com/viash-io/viash/issues"
+    |""".stripMargin, "yaml")
 @since("Viash 0.9.0")
 case class ProjectConfigLinks(
   @description("Source repository url.")

--- a/src/main/scala/io/viash/project/ProjectConfigReferences.scala
+++ b/src/main/scala/io/viash/project/ProjectConfigReferences.scala
@@ -21,6 +21,16 @@ import io.viash.schemas._
 import io.viash.helpers.data_structures.OneOrMore
 
 @description("References to external resources related to the project.")
+@example(
+  """doi: 10.1000/xx.123456.789
+    |bibtex: |
+    |  @article{foo,
+    |    title={Foo},
+    |    author={Bar},
+    |    journal={Baz},
+    |    year={2024}
+    |  }
+    |""".stripMargin, "yaml")
 @since("Viash 0.9.0")
 case class ProjectConfigReferences(
   @description("One or multiple DOI reference(s) of the project.")

--- a/src/main/scala/io/viash/schemas/CollectedSchemas.scala
+++ b/src/main/scala/io/viash/schemas/CollectedSchemas.scala
@@ -32,7 +32,7 @@ import monocle.function.Cons
 import io.viash.config.Config
 import io.viash.config.Info
 import io.viash.functionality.resources._
-import io.viash.project.ProjectConfig
+import io.viash.project.{ProjectConfig, ProjectConfigLinks, ProjectConfigReferences}
 import io.viash.helpers._
 import scala.collection.immutable.ListMap
 import io.viash.functionality.dependencies._
@@ -118,6 +118,8 @@ object CollectedSchemas {
   lazy val schemaClasses = List(
     getMembers[Config](),
     getMembers[ProjectConfig](),
+    getMembers[ProjectConfigLinks](),
+    getMembers[ProjectConfigReferences](),
     getMembers[Info](),
     getMembers[SysEnvTrait](),
 

--- a/src/test/scala/io/viash/e2e/build/DockerMeta.scala
+++ b/src/test/scala/io/viash/e2e/build/DockerMeta.scala
@@ -58,11 +58,11 @@ class DockerMeta extends AnyFunSuite with BeforeAndAfterAll {
       val viashVersion = io.viash.Main.version
 
       val regexViashVersion = s"""viash_version: "${viashVersion}"""".r
-      val regexConfig = s"""config: "${configFile}"""".r
+      val regexConfig = """config: "\[anonymized\]/config.vsh.yaml"""".r
       val regexEngine = """engine: "docker"""".r
       val regexRunner = """runner: "docker"""".r
-      val regexExecutable = s"""executable: "$binDir/testbash"""".r
-      val regexOutput = s"""output: "$binDir"""".r
+      val regexExecutable = """executable: "\[anonymized\]/testbash"""".r
+      val regexOutput = """output: "\[anonymized\]/bin"""".r
       val regexNoRemoteGitRepo = "git_remote:".r
 
       assert(regexViashVersion.findFirstIn(metaStr).isDefined, stdout)
@@ -130,11 +130,11 @@ class DockerMeta extends AnyFunSuite with BeforeAndAfterAll {
       val viashVersion = io.viash.Main.version
 
       val regexViashVersion = s"""viash_version: "$viashVersion"""".r
-      val regexConfig = s"""config: "$configMetaFile"""".r
+      val regexConfig = """config: "\[anonymized\]/config.vsh.yaml"""".r
       val regexEngine = """engine: "docker"""".r
       val regexRunner = """runner: "docker"""".r
-      val regexExecutable = s"""executable: "$binDir/testbash"""".r
-      val regexOutput = s"""output: "$binDir"""".r
+      val regexExecutable = """executable: "\[anonymized\]/testbash"""".r
+      val regexOutput = """output: "\[anonymized\]/bin"""".r
       val regexRemoteGitRepo = s"""git_remote: "$fakeGitRepo"""".r
 
       assert(regexViashVersion.findFirstIn(metaStr).isDefined, stdout)
@@ -193,11 +193,11 @@ class DockerMeta extends AnyFunSuite with BeforeAndAfterAll {
       val viashVersion = io.viash.Main.version
 
       val regexViashVersion = s"""viash_version: "$viashVersion"""".r
-      val regexConfig = s"""config: "$configMetaFile"""".r
+      val regexConfig = """config: "\[anonymized\]/config.vsh.yaml"""".r
       val regexEngine = """engine: "docker"""".r
       val regexRunner = """runner: "docker"""".r
-      val regexExecutable = s"""executable: "$binDir/testbash"""".r
-      val regexOutput = s"""output: "$binDir"""".r
+      val regexExecutable = """executable: "\[anonymized\]/testbash"""".r
+      val regexOutput = """output: "\[anonymized\]/bin"""".r
       val regexRemoteGitRepo = """git_remote:"""".r
 
       assert(regexViashVersion.findFirstIn(metaStr).isDefined, stdout)

--- a/src/test/scala/io/viash/e2e/config_view/MainConfigViewSuite.scala
+++ b/src/test/scala/io/viash/e2e/config_view/MainConfigViewSuite.scala
@@ -33,7 +33,7 @@ class MainConfigViewSuite extends AnyFunSuite{
     assert(testOutput.stdout.contains("testbash"))
   }
 
-  test("viash config view without anonymized paths") {
+  test("viash config view wit anonymized paths") {
     // Output is not anonymized when no project config is found, and that can't be found unless we pass the workingDir
     val testOutput = TestHelper.testMain(
       // workingDir = Some(Paths.get(workingDirAnonymizing)),
@@ -41,10 +41,10 @@ class MainConfigViewSuite extends AnyFunSuite{
       configFileAnonymizing
     )
 
-    assert(testOutput.stdout.contains(s"""config: "${workingDirAnonymizing}src/ns_add/config.vsh.yaml""""))
+    assert(testOutput.stdout.contains(s"""config: "[anonymized]/config.vsh.yaml""""))
   }
 
-  test("viash config view with anonymized paths") {
+  test("viash config view with relative anonymous paths") {
     val testOutput = TestHelper.testMain(
       workingDir = Some(Paths.get(workingDirAnonymizing)),
       "config", "view",

--- a/src/test/scala/io/viash/e2e/config_view/MainConfigViewSuite.scala
+++ b/src/test/scala/io/viash/e2e/config_view/MainConfigViewSuite.scala
@@ -4,13 +4,14 @@ import io.viash._
 import io.viash.helpers.Logger
 
 import org.scalatest.funsuite.AnyFunSuite
+import java.nio.file.Paths
 
 class MainConfigViewSuite extends AnyFunSuite{
   Logger.UseColorOverride.value = Some(false)
   // path to namespace components
   private val configFile = getClass.getResource(s"/testbash/config.vsh.yaml").getPath
-
-
+  private val workingDirAnonymizing = getClass.getResource("/testns/").getPath()
+  private val configFileAnonymizing = getClass.getResource("/testns/src/ns_add/config.vsh.yaml").getPath
 
   test("viash config view local") {
     val testOutput = TestHelper.testMain(
@@ -30,6 +31,27 @@ class MainConfigViewSuite extends AnyFunSuite{
 
     assert(testOutput.stdout.startsWith("functionality:"))
     assert(testOutput.stdout.contains("testbash"))
+  }
+
+  test("viash config view without anonymized paths") {
+    // Output is not anonymized when no project config is found, and that can't be found unless we pass the workingDir
+    val testOutput = TestHelper.testMain(
+      // workingDir = Some(Paths.get(workingDirAnonymizing)),
+      "config", "view",
+      configFileAnonymizing
+    )
+
+    assert(testOutput.stdout.contains(s"""config: "${workingDirAnonymizing}src/ns_add/config.vsh.yaml""""))
+  }
+
+  test("viash config view with anonymized paths") {
+    val testOutput = TestHelper.testMain(
+      workingDir = Some(Paths.get(workingDirAnonymizing)),
+      "config", "view",
+      configFileAnonymizing
+    )
+
+    assert(testOutput.stdout.contains("""config: "src/ns_add/config.vsh.yaml""""))
   }
 
 }

--- a/src/test/scala/io/viash/helpers/IOTest.scala
+++ b/src/test/scala/io/viash/helpers/IOTest.scala
@@ -117,8 +117,8 @@ class IOTest extends AnyFunSuite with BeforeAndAfter {
     assert(result == "[anonymized]/test.txt")
   }
 
-  test("anonymizePath with a common path and a trailing slash") {
-    val basePath = Some(Paths.get("/foo/bar"))
+  test("anonymizePath with a common path with a trailing slash") {
+    val basePath = Some(Paths.get("/foo/bar/"))
     val path = "/foo/bar/baz/test.txt"
     val result = IO.anonymizePath(basePath, path)
     assert(result == "baz/test.txt")

--- a/src/test/scala/io/viash/helpers/IOTest.scala
+++ b/src/test/scala/io/viash/helpers/IOTest.scala
@@ -106,14 +106,14 @@ class IOTest extends AnyFunSuite with BeforeAndAfter {
     val basePath = "/foo/bar"
     val path = "/foo/baz/test.txt"
     val result = IO.anonymizePath(basePath, path)
-    assert(result == path)
+    assert(result == "[anonymized]/test.txt")
   }
 
   test("anynimizePath with a completely different base path") {
     val basePath = "/foo/bar"
     val path = "/tmp/foo/bar/baz/test.txt"
     val result = IO.anonymizePath(basePath, path)
-    assert(result == path)
+    assert(result == "[anonymized]/test.txt")
   }
 
   test("anonymizePath with a common path and a trailing slash") {

--- a/src/test/scala/io/viash/helpers/IOTest.scala
+++ b/src/test/scala/io/viash/helpers/IOTest.scala
@@ -94,4 +94,32 @@ class IOTest extends AnyFunSuite with BeforeAndAfter {
     val result = Try(IO.resolveProjectPath("/test/test.txt", None))
     assert(result.isFailure)
   }
+
+  test("anonymizePath with a common path") {
+    val basePath = "/foo/bar"
+    val path = "/foo/bar/baz/test.txt"
+    val result = IO.anonymizePath(basePath, path)
+    assert(result == "baz/test.txt")
+  }
+
+  test("anonymizePath with a different base path") {
+    val basePath = "/foo/bar"
+    val path = "/foo/baz/test.txt"
+    val result = IO.anonymizePath(basePath, path)
+    assert(result == path)
+  }
+
+  test("anynimizePath with a completely different base path") {
+    val basePath = "/foo/bar"
+    val path = "/tmp/foo/bar/baz/test.txt"
+    val result = IO.anonymizePath(basePath, path)
+    assert(result == path)
+  }
+
+  test("anonymizePath with a common path and a trailing slash") {
+    val basePath = "/foo/bar/"
+    val path = "/foo/bar/baz/test.txt"
+    val result = IO.anonymizePath(basePath, path)
+    assert(result == "baz/test.txt")
+  }
 }


### PR DESCRIPTION
## Describe your changes

Anonymize configs before outputting them, either to console or file

Add .config.projectDir so we can always access it without always having to pass the path as an argument to functions
Set .config.projectDir to @internalFunctionality so it's never outputted (would defeat the whole purpose)
This could potentially clean up more code, but this is not done yet

What if there is no projectDir set (no viash project file found). We'll still be outputting full paths!

## Related issue(s)

Closes #20 

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [ ] Minor change (non-breaking change which does not modify existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [x] I have performed a self-review of my code by checking the "Changed Files" tab.
- [x] My code follows the code style of this project.

Tests:

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

Documentation:

- [x] Proposed changes are described in the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.

## Test Environment

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test environment.
-->

