### PR TITLE
Don't override ProjectConfig as Project in schema exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ TODO add summary
 
 * `Java 21 support`: Update Scala to 2.13.12 and update dependencies (PR #602).
 
+* `project config`: Output the project config under the default name `ProjectConfig` instead of `Project` during schema export (PR #631). This is now important as the project config is now part of the component config. Previously this was overridden as the class name was `ViashProject` which was less descriptive.
+
 ## BUG FIXES
 
 * `__merge__`: Handle invalid yaml during merging (PR #570). There was not enough error handling during this operation. Switched to the more advanced `Convert.textToJson` helper method.

--- a/src/main/scala/io/viash/project/ProjectConfig.scala
+++ b/src/main/scala/io/viash/project/ProjectConfig.scala
@@ -44,7 +44,6 @@ import io.viash.functionality.Author
     |""".stripMargin, "yaml"
 )
 @since("Viash 0.6.4")
-@nameOverride("Project")
 case class ProjectConfig(
   @description("The name of the project.")
   @example("name: my_project", "yaml")


### PR DESCRIPTION
## Describe your changes

Output the project config under the default name `ProjectConfig` instead of `Project` during schema export.

This is now important as the project config is now part of the component config. Previously this was overridden as the class name was `ViashProject` which was less descriptive.

## Related issue(s)

<!-- Replace xxxx with the GitHub issue number. -->

Closes #xxxx 

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [x] Minor change (non-breaking change which does not modify existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [x] I have performed a self-review of my code by checking the "Changed Files" tab.
- [x] My code follows the code style of this project.

Tests:

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

Documentation:

- [x] Proposed changes are described in the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.

## Test Environment

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test environment.
-->

