### PR TITLE
Add `--dry_run` to `viash [ns] test` for generating test scripts

### DIFF
--- a/src/main/scala/io/viash/Main.scala
+++ b/src/main/scala/io/viash/Main.scala
@@ -243,8 +243,8 @@ object Main extends Logging {
       case List(cli.test) =>
         val config = readConfig(cli.test, packageConfig = pack1)
         val config2 = singleConfigDependencies(config, None, pack1.rootDir)
-        if (cli.test.justGenerate.getOrElse(false) && !cli.test.keep.toOption.map(_.toBoolean).getOrElse(false)) {
-          info("Warning: --just_generate is set, but --keep is not set. This will result in the generated files being deleted after the test.")
+        if (cli.test.dryRun.getOrElse(false) && !cli.test.keep.toOption.map(_.toBoolean).getOrElse(false)) {
+          info("Warning: --dry_run is set, but --keep is not set. This will result in the generated files being deleted after the test.")
         }
         ViashTest(
           config2,
@@ -252,7 +252,7 @@ object Main extends Logging {
           setupStrategy = cli.test.setup.toOption,
           cpus = cli.test.cpus.toOption,
           memory = cli.test.memory.toOption,
-          just_generate = cli.test.justGenerate.toOption
+          dryRun = cli.test.dryRun.toOption
         )
         0 // Exceptions are thrown when a test fails, so then the '0' is not returned but a '1'. Can be improved further.
       case List(cli.namespace, cli.namespace.build) =>
@@ -280,8 +280,8 @@ object Main extends Logging {
             ac.copy(engines = List(engine))
           }
         }
-        if (cli.namespace.test.justGenerate.getOrElse(false) && !cli.namespace.test.keep.toOption.map(_.toBoolean).getOrElse(false)) {
-          info("Warning: --just_generate is set, but --keep is not set. This will result in the generated files being deleted after the test.")
+        if (cli.namespace.test.dryRun.getOrElse(false) && !cli.namespace.test.keep.toOption.map(_.toBoolean).getOrElse(false)) {
+          info("Warning: --dry_run is set, but --keep is not set. This will result in the generated files being deleted after the test.")
         }
         val testResults = ViashNamespace.test(
           configs = configs3,
@@ -292,7 +292,7 @@ object Main extends Logging {
           cpus = cli.namespace.test.cpus.toOption,
           memory = cli.namespace.test.memory.toOption,
           setup = cli.namespace.test.setup.toOption,
-          just_generate = cli.namespace.test.justGenerate.toOption
+          dryRun = cli.namespace.test.dryRun.toOption
         )
         val errors = testResults.map(_._1).flatMap(_.status).count(_.isError)
         if (errors > 0) 1 else 0

--- a/src/main/scala/io/viash/Main.scala
+++ b/src/main/scala/io/viash/Main.scala
@@ -249,7 +249,7 @@ object Main extends Logging {
           setupStrategy = cli.test.setup.toOption,
           cpus = cli.test.cpus.toOption,
           memory = cli.test.memory.toOption,
-          just_generate = false
+          just_generate = None
         )
         0 // Exceptions are thrown when a test fails, so then the '0' is not returned but a '1'. Can be improved further.
       case List(cli.namespace, cli.namespace.build) =>
@@ -285,30 +285,8 @@ object Main extends Logging {
           append = cli.namespace.test.append(),
           cpus = cli.namespace.test.cpus.toOption,
           memory = cli.namespace.test.memory.toOption,
-          setup = cli.namespace.test.setup.toOption
-        )
-        val errors = testResults.map(_._1).flatMap(_.status).count(_.isError)
-        if (errors > 0) 1 else 0
-      case List(cli.namespace, cli.namespace.generateTest) =>
-        val configs = readConfigs(cli.namespace.test, packageConfig = pack1)
-        // resolve dependencies
-        val configs2 = namespaceDependencies(configs, None, pack1.rootDir)
-        // flatten engines
-        val configs3 = configs2.flatMap{ ac => 
-          ac.engines.map{ engine => 
-            ac.copy(engines = List(engine))
-          }
-        }
-        val testResults = ViashNamespace.test(
-          configs = configs3,
-          parallel = cli.namespace.test.parallel(),
-          keepFiles = cli.namespace.test.keep.toOption.map(_.toBoolean),
-          tsv = cli.namespace.test.tsv.toOption,
-          append = cli.namespace.test.append(),
-          cpus = cli.namespace.test.cpus.toOption,
-          memory = cli.namespace.test.memory.toOption,
           setup = cli.namespace.test.setup.toOption,
-          just_generate = true
+          just_generate = cli.namespace.test.justGenerate.toOption
         )
         val errors = testResults.map(_._1).flatMap(_.status).count(_.isError)
         if (errors > 0) 1 else 0

--- a/src/main/scala/io/viash/Main.scala
+++ b/src/main/scala/io/viash/Main.scala
@@ -243,13 +243,16 @@ object Main extends Logging {
       case List(cli.test) =>
         val config = readConfig(cli.test, packageConfig = pack1)
         val config2 = singleConfigDependencies(config, None, pack1.rootDir)
+        if (cli.test.justGenerate.getOrElse(false) && !cli.test.keep.toOption.map(_.toBoolean).getOrElse(false)) {
+          info("Warning: --just_generate is set, but --keep is not set. This will result in the generated files being deleted after the test.")
+        }
         ViashTest(
           config2,
           keepFiles = cli.test.keep.toOption.map(_.toBoolean),
           setupStrategy = cli.test.setup.toOption,
           cpus = cli.test.cpus.toOption,
           memory = cli.test.memory.toOption,
-          just_generate = None
+          just_generate = cli.test.justGenerate.toOption
         )
         0 // Exceptions are thrown when a test fails, so then the '0' is not returned but a '1'. Can be improved further.
       case List(cli.namespace, cli.namespace.build) =>
@@ -276,6 +279,9 @@ object Main extends Logging {
           ac.engines.map{ engine => 
             ac.copy(engines = List(engine))
           }
+        }
+        if (cli.namespace.test.justGenerate.getOrElse(false) && !cli.namespace.test.keep.toOption.map(_.toBoolean).getOrElse(false)) {
+          info("Warning: --just_generate is set, but --keep is not set. This will result in the generated files being deleted after the test.")
         }
         val testResults = ViashNamespace.test(
           configs = configs3,

--- a/src/main/scala/io/viash/ViashNamespace.scala
+++ b/src/main/scala/io/viash/ViashNamespace.scala
@@ -128,7 +128,7 @@ object ViashNamespace extends Logging {
     append: Boolean = false,
     cpus: Option[Int],
     memory: Option[String],
-    just_generate: Boolean = false
+    just_generate: Option[Boolean] = None
   ): List[(AppliedConfig, ManyTestOutput)] = {
     val configs1 = configs.filter{tup => tup match {
       // remove nextflow because unit testing nextflow modules

--- a/src/main/scala/io/viash/ViashNamespace.scala
+++ b/src/main/scala/io/viash/ViashNamespace.scala
@@ -128,7 +128,7 @@ object ViashNamespace extends Logging {
     append: Boolean = false,
     cpus: Option[Int],
     memory: Option[String],
-    just_generate: Option[Boolean] = None
+    dryRun: Option[Boolean] = None
   ): List[(AppliedConfig, ManyTestOutput)] = {
     val configs1 = configs.filter{tup => tup match {
       // remove nextflow because unit testing nextflow modules
@@ -190,7 +190,7 @@ object ViashNamespace extends Logging {
                 parentTempPath = Some(parentTempPath),
                 cpus = cpus,
                 memory = memory,
-                just_generate = just_generate
+                dryRun = dryRun
               )
             } catch {
               case e: MissingResourceFileException => 

--- a/src/main/scala/io/viash/ViashNamespace.scala
+++ b/src/main/scala/io/viash/ViashNamespace.scala
@@ -127,7 +127,8 @@ object ViashNamespace extends Logging {
     tsv: Option[String] = None,
     append: Boolean = false,
     cpus: Option[Int],
-    memory: Option[String]
+    memory: Option[String],
+    just_generate: Boolean = false
   ): List[(AppliedConfig, ManyTestOutput)] = {
     val configs1 = configs.filter{tup => tup match {
       // remove nextflow because unit testing nextflow modules
@@ -188,7 +189,8 @@ object ViashNamespace extends Logging {
                 quiet = true,
                 parentTempPath = Some(parentTempPath),
                 cpus = cpus,
-                memory = memory
+                memory = memory,
+                just_generate = just_generate
               )
             } catch {
               case e: MissingResourceFileException => 

--- a/src/main/scala/io/viash/ViashTest.scala
+++ b/src/main/scala/io/viash/ViashTest.scala
@@ -70,7 +70,7 @@ object ViashTest extends Logging {
     parentTempPath: Option[Path] = None, 
     cpus: Option[Int], 
     memory: Option[String],
-    just_generate: Boolean = false
+    just_generate: Option[Boolean] = None
   ): ManyTestOutput = {
     // create temporary directory
     val dir = IO.makeTemp("viash_test_" + configNameLens.get(appliedConfig), parentTempPath)
@@ -145,7 +145,7 @@ object ViashTest extends Logging {
     verbosityLevel: Int, 
     cpus: Option[Int], 
     memory: Option[String],
-    just_generate: Boolean
+    just_generate: Option[Boolean]
   ): ManyTestOutput = {
     val conf = appliedConfig.config
 
@@ -315,7 +315,7 @@ object ViashTest extends Logging {
           val subTmp = Paths.get(newDir.toString, "tmp")
           Files.createDirectories(subTmp)
 
-          val cmd = if (just_generate)
+          val cmd = if (just_generate.getOrElse(false))
             Seq("echo", "Running dummy test script")
           else
             Seq(executable) ++ Seq(cpus.map("---cpus=" + _), memory.map("---memory="+_)).flatMap(a => a)

--- a/src/main/scala/io/viash/ViashTest.scala
+++ b/src/main/scala/io/viash/ViashTest.scala
@@ -70,7 +70,7 @@ object ViashTest extends Logging {
     parentTempPath: Option[Path] = None, 
     cpus: Option[Int], 
     memory: Option[String],
-    just_generate: Option[Boolean] = None
+    dryRun: Option[Boolean] = None
   ): ManyTestOutput = {
     // create temporary directory
     val dir = IO.makeTemp("viash_test_" + configNameLens.get(appliedConfig), parentTempPath)
@@ -96,7 +96,7 @@ object ViashTest extends Logging {
       verbosityLevel = verbosityLevel,
       cpus = cpus,
       memory = memory,
-      just_generate = just_generate
+      dryRun = dryRun
     )
     val count = results.count(_.exitValue == 0)
     val anyErrors = setupRes.exists(_.exitValue > 0) || count < results.length
@@ -145,7 +145,7 @@ object ViashTest extends Logging {
     verbosityLevel: Int, 
     cpus: Option[Int], 
     memory: Option[String],
-    just_generate: Option[Boolean]
+    dryRun: Option[Boolean]
   ): ManyTestOutput = {
     val conf = appliedConfig.config
 
@@ -315,7 +315,7 @@ object ViashTest extends Logging {
           val subTmp = Paths.get(newDir.toString, "tmp")
           Files.createDirectories(subTmp)
 
-          val cmd = if (just_generate.getOrElse(false))
+          val cmd = if (dryRun.getOrElse(false))
             Seq("echo", "Running dummy test script")
           else
             Seq(executable) ++ Seq(cpus.map("---cpus=" + _), memory.map("---memory="+_)).flatMap(a => a)

--- a/src/main/scala/io/viash/cli/CLIConf.scala
+++ b/src/main/scala/io/viash/cli/CLIConf.scala
@@ -440,7 +440,6 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
 
     addSubcommand(build)
     addSubcommand(test)
-    // addSubcommand(generateTest)
     addSubcommand(list)
     addSubcommand(exec)
     requireSubcommand()

--- a/src/main/scala/io/viash/cli/CLIConf.scala
+++ b/src/main/scala/io/viash/cli/CLIConf.scala
@@ -259,10 +259,10 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
       default = None,
       descr = "Which @[setup strategy](docker_setup_strategy) for creating the container to use [Docker Engine only]."
     )
-    val justGenerate = registerOpt[Boolean](
-      name= "just_generate",
+    val dryRun = registerOpt[Boolean](
+      name= "dry_run",
       default = Some(false),
-      descr = "Only generate the test script, do not run it."
+      descr = "Only generate the test script, do not run the test."
     )
 
     footer(
@@ -355,8 +355,8 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
         default = Some(false),
         descr = "Append to tsv instead of overwrite"
       )
-      val justGenerate = registerOpt[Boolean](
-        name= "just_generate",
+      val dryRun = registerOpt[Boolean](
+        name= "dry_run",
         default = Some(false),
         descr = "Only generate the test scripts, do not run them."
       )

--- a/src/main/scala/io/viash/cli/CLIConf.scala
+++ b/src/main/scala/io/viash/cli/CLIConf.scala
@@ -262,7 +262,8 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
     val dryRun = registerOpt[Boolean](
       name= "dry_run",
       default = Some(false),
-      descr = "Only generate the test script, do not run the test."
+      descr = "Only generate the test script, do not run the test.",
+      hidden = true
     )
 
     footer(
@@ -358,7 +359,8 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
       val dryRun = registerOpt[Boolean](
         name= "dry_run",
         default = Some(false),
-        descr = "Only generate the test scripts, do not run them."
+        descr = "Only generate the test scripts, do not run them.",
+        hidden = true
       )
     }
 

--- a/src/main/scala/io/viash/cli/CLIConf.scala
+++ b/src/main/scala/io/viash/cli/CLIConf.scala
@@ -327,32 +327,6 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
       )
     }
 
-    val generateTest = new DocumentedSubcommand("generate_test") with ViashNs with WithTemporary with ViashRunner with ViashLogger {
-      hidden = true
-      banner(
-        "viash ns generate_test",
-        "Generate test scripts for a namespace containing many viash config files.",
-        "viash ns generate_test [-n nmspc] [-s src] [-p docker] [--parallel]")
-
-      val setup = registerOpt[String](
-        name = "setup",
-        default = None,
-        descr = "Which @[setup strategy](docker_setup_strategy) for creating the container to use [Docker Engine only]."
-      )
-
-      val tsv = registerOpt[String](
-        name = "tsv",
-        short = Some('t'),
-        descr = "Path to write a summary of the test results to."
-      )
-      val append = registerOpt[Boolean](
-        name = "append",
-        short = Some('a'),
-        default = Some(false),
-        descr = "Append to tsv instead of overwrite"
-      )
-    }
-
     val test = new DocumentedSubcommand("test") with ViashNs with WithTemporary with ViashRunner with ViashLogger {
       banner(
         "viash ns test",
@@ -375,6 +349,11 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
         short = Some('a'),
         default = Some(false),
         descr = "Append to tsv instead of overwrite"
+      )
+      val justGenerate = registerOpt[Boolean](
+        name= "just_generate",
+        default = Some(false),
+        descr = "Only generate the test scripts, do not run them."
       )
     }
 
@@ -461,7 +440,7 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
 
     addSubcommand(build)
     addSubcommand(test)
-    addSubcommand(generateTest)
+    // addSubcommand(generateTest)
     addSubcommand(list)
     addSubcommand(exec)
     requireSubcommand()

--- a/src/main/scala/io/viash/cli/CLIConf.scala
+++ b/src/main/scala/io/viash/cli/CLIConf.scala
@@ -327,6 +327,32 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
       )
     }
 
+    val generateTest = new DocumentedSubcommand("generate_test") with ViashNs with WithTemporary with ViashRunner with ViashLogger {
+      // hidden = true
+      banner(
+        "viash ns generate_test",
+        "Generate test scripts for a namespace containing many viash config files.",
+        "viash ns generate_test [-n nmspc] [-s src] [-p docker] [--parallel]")
+
+      val setup = registerOpt[String](
+        name = "setup",
+        default = None,
+        descr = "Which @[setup strategy](docker_setup_strategy) for creating the container to use [Docker Engine only]."
+      )
+
+      val tsv = registerOpt[String](
+        name = "tsv",
+        short = Some('t'),
+        descr = "Path to write a summary of the test results to."
+      )
+      val append = registerOpt[Boolean](
+        name = "append",
+        short = Some('a'),
+        default = Some(false),
+        descr = "Append to tsv instead of overwrite"
+      )
+    }
+
     val test = new DocumentedSubcommand("test") with ViashNs with WithTemporary with ViashRunner with ViashLogger {
       banner(
         "viash ns test",
@@ -435,6 +461,7 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
 
     addSubcommand(build)
     addSubcommand(test)
+    addSubcommand(generateTest)
     addSubcommand(list)
     addSubcommand(exec)
     requireSubcommand()

--- a/src/main/scala/io/viash/cli/CLIConf.scala
+++ b/src/main/scala/io/viash/cli/CLIConf.scala
@@ -252,14 +252,19 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
       "viash test",
       "Test the component using the tests defined in the viash config file.",
       "viash test config.vsh.yaml [-p docker] [-k true/false] [--setup cachedbuild]")
-    
+
     val setup = registerOpt[String](
       name = "setup",
       short = Some('s'),
       default = None,
       descr = "Which @[setup strategy](docker_setup_strategy) for creating the container to use [Docker Engine only]."
     )
-    
+    val justGenerate = registerOpt[Boolean](
+      name= "just_generate",
+      default = Some(false),
+      descr = "Only generate the test script, do not run it."
+    )
+
     footer(
       s"""
          |The temporary directory can be altered by setting the VIASH_TEMP directory. Example:

--- a/src/main/scala/io/viash/cli/CLIConf.scala
+++ b/src/main/scala/io/viash/cli/CLIConf.scala
@@ -328,7 +328,7 @@ class CLIConf(arguments: Seq[String]) extends ScallopConf(arguments) with Loggin
     }
 
     val generateTest = new DocumentedSubcommand("generate_test") with ViashNs with WithTemporary with ViashRunner with ViashLogger {
-      // hidden = true
+      hidden = true
       banner(
         "viash ns generate_test",
         "Generate test scripts for a namespace containing many viash config files.",

--- a/src/test/scala/io/viash/e2e/ns_test/MainNSTestNativeSuite.scala
+++ b/src/test/scala/io/viash/e2e/ns_test/MainNSTestNativeSuite.scala
@@ -97,12 +97,12 @@ class MainNSTestNativeSuite extends AnyFunSuite with BeforeAndAfterAll {
     assert(regexBuildError.findFirstIn(testOutput.stderr).isDefined, "Expecting to get an error because of an invalid yaml in ns_error")
   }
   
-  test("Check namespace test output with working dir message using --just_generate") {
+  test("Check namespace test output with working dir message using --dry_run") {
     val testOutput = TestHelper.testMain(
       "ns", "test",
       "--src", nsPath,
       "--keep", "true",
-      "--just_generate"
+      "--dry_run"
     )
 
     // Test inclusion of a header

--- a/src/test/scala/io/viash/e2e/ns_test/MainNSTestNativeSuite.scala
+++ b/src/test/scala/io/viash/e2e/ns_test/MainNSTestNativeSuite.scala
@@ -102,7 +102,6 @@ class MainNSTestNativeSuite extends AnyFunSuite with BeforeAndAfterAll {
       "ns", "test",
       "--src", nsPath,
       "--keep", "true",
-      "--runner", "native",
       "--just_generate"
     )
 

--- a/src/test/scala/io/viash/e2e/ns_test/MainNSTestNativeSuite.scala
+++ b/src/test/scala/io/viash/e2e/ns_test/MainNSTestNativeSuite.scala
@@ -96,6 +96,34 @@ class MainNSTestNativeSuite extends AnyFunSuite with BeforeAndAfterAll {
     val regexBuildError = raw"Reading file \'.*/src/ns_error/config\.vsh\.yaml\' failed".r
     assert(regexBuildError.findFirstIn(testOutput.stderr).isDefined, "Expecting to get an error because of an invalid yaml in ns_error")
   }
+  
+  test("Check namespace test output with working dir message using --just_generate") {
+    val testOutput = TestHelper.testMain(
+      "ns", "test",
+      "--src", nsPath,
+      "--keep", "true",
+      "--runner", "native",
+      "--just_generate"
+    )
+
+    // Test inclusion of a header
+    val regexHeader = s"^\\s*${ViashNamespace.columnHeaders.mkString("\\s*")}".r
+    assert(regexHeader.findFirstIn(testOutput.stdout).isDefined, s"\nRegex: ${regexHeader.toString}; text: \n${testOutput.stdout}")
+
+    val regexWdir = raw"The working directory for the namespace tests is [\w/]+[\r\n]{1,2}".r
+    assert(regexWdir.findFirstIn(testOutput.stderr).isDefined, s"\nRegex: ${regexHeader.toString}; text: \n${testOutput.stderr}")
+
+    for (
+      (component, steps) <- components;
+      (step, resultPattern) <- steps
+    ) {
+      val regex = s"""testns\\s*$component\\s*executable\\s*native\\s*$step$resultPattern""".r
+      assert(regex.findFirstIn(testOutput.stdout).isDefined, s"\nRegex: '${regex.toString}'; text: \n${testOutput.stdout}")
+    }
+
+    val regexBuildError = raw"Reading file \'.*/src/ns_error/config\.vsh\.yaml\' failed".r
+    assert(regexBuildError.findFirstIn(testOutput.stderr).isDefined, "Expecting to get an error because of an invalid yaml in ns_error")
+  }
 
   test("Check namespace test output with tsv option") {
     val log = Paths.get(tempFolStr, "log.tsv").toFile

--- a/src/test/scala/io/viash/e2e/ns_test/MainNSTestNativeSuite.scala
+++ b/src/test/scala/io/viash/e2e/ns_test/MainNSTestNativeSuite.scala
@@ -116,7 +116,13 @@ class MainNSTestNativeSuite extends AnyFunSuite with BeforeAndAfterAll {
       (component, steps) <- components;
       (step, resultPattern) <- steps
     ) {
-      val regex = s"""testns\\s*$component\\s*executable\\s*native\\s*$step$resultPattern""".r
+      // In this mode, a test script can never return an ERROR
+      val updtResultPattern = if (resultPattern == raw"\s*1\s*\d+\s*ERROR") {
+        raw"\s*0\s*\d+\s*SUCCESS"
+      } else {
+        resultPattern
+      }
+      val regex = s"""testns\\s*$component\\s*executable\\s*native\\s*$step$updtResultPattern""".r
       assert(regex.findFirstIn(testOutput.stdout).isDefined, s"\nRegex: '${regex.toString}'; text: \n${testOutput.stdout}")
     }
 

--- a/src/test/scala/io/viash/e2e/test/MainTestNativeSuite.scala
+++ b/src/test/scala/io/viash/e2e/test/MainTestNativeSuite.scala
@@ -315,6 +315,22 @@ class MainTestNativeSuite extends AnyFunSuite with BeforeAndAfterAll {
     checkTempDirAndRemove(testOutput.stdout, true)
   }
 
+  test("Check output in case --just_generate is specified") {
+    val testOutput = TestHelper.testMain(
+      "test",
+      "--engine", "native",
+      "--runner", "executable",
+      "--just_generate",
+      configFile
+    )
+    assert(testOutput.stdout.contains("Running tests in temporary directory: "))
+    assert(testOutput.stdout.contains("Running dummy test script"))
+    assert(testOutput.stdout.contains("SUCCESS! All 2 out of 2 test scripts succeeded!"))
+    assert(testOutput.stdout.contains("Cleaning up temporary directory"))
+
+    checkTempDirAndRemove(testOutput.stdout, false)
+  }
+
   test("Check output in case --keep false is specified") {
     val testOutput = TestHelper.testMain(
       "test",

--- a/src/test/scala/io/viash/e2e/test/MainTestNativeSuite.scala
+++ b/src/test/scala/io/viash/e2e/test/MainTestNativeSuite.scala
@@ -315,12 +315,12 @@ class MainTestNativeSuite extends AnyFunSuite with BeforeAndAfterAll {
     checkTempDirAndRemove(testOutput.stdout, true)
   }
 
-  test("Check output in case --just_generate is specified") {
+  test("Check output in case --dry_run is specified") {
     val testOutput = TestHelper.testMain(
       "test",
       "--engine", "native",
       "--runner", "executable",
-      "--just_generate",
+      "--dry_run",
       configFile
     )
     assert(testOutput.stdout.contains("Running tests in temporary directory: "))


### PR DESCRIPTION
## Describe your changes

During CI runs, we need the ability to split generating the test files and running them. This argument generates the test scripts.



## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [ ] Minor change (non-breaking change which does not modify existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [ ] I have performed a self-review of my code by checking the "Changed Files" tab.
- [ ] My code follows the code style of this project.

Tests:

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

Documentation:

- [ ] Proposed changes are described in the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.

