### PR TITLE
Fix an issue where if the first resource is not a script, the resource is silently dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * `Executable`: Check whether a multiple output file argument contains a wildcard (PR #639).
 
-* `Resources`: Fix an issue where if the first resource is not a script, the resource is silently dropped (PR #xxx).
+* `Resources`: Fix an issue where if the first resource is not a script, the resource is silently dropped (PR #670).
 
 # Viash 0.8.5 (2024-02-21): Bug fixes and documentation improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * `Executable`: Check whether a multiple output file argument contains a wildcard (PR #639).
 
+* `Resources`: Fix an issue where if the first resource is not a script, the resource is silently dropped (PR #xxx).
+
 # Viash 0.8.5 (2024-02-21): Bug fixes and documentation improvements
 
 Fix a bug when building a test docker container which requires a test resource. Additional improvements for the website documentation and support for the latest version of Nextflow are added.

--- a/src/main/scala/io/viash/functionality/Functionality.scala
+++ b/src/main/scala/io/viash/functionality/Functionality.scala
@@ -372,8 +372,10 @@ case class Functionality(
     }
   def mainCode: Option[String] = mainScript.flatMap(_.read)
   // provide function to use resources.tail but that allows resources to be an empty list
+  // If mainScript ends up being None because the first resource isn't a script, return the whole list
   def additionalResources = resources match {
-    case _ :: tail => tail
+    case head :: tail if head.isInstanceOf[Script] => tail
+    case list if list.nonEmpty => list
     case _ => List.empty[Resource]
   }
 

--- a/src/main/scala/io/viash/functionality/Functionality.scala
+++ b/src/main/scala/io/viash/functionality/Functionality.scala
@@ -375,8 +375,7 @@ case class Functionality(
   // If mainScript ends up being None because the first resource isn't a script, return the whole list
   def additionalResources = resources match {
     case head :: tail if head.isInstanceOf[Script] => tail
-    case list if list.nonEmpty => list
-    case _ => List.empty[Resource]
+    case list => list
   }
 
   def isEnabled: Boolean = status != Status.Disabled

--- a/src/test/scala/io/viash/functionality/MainScriptTest.scala
+++ b/src/test/scala/io/viash/functionality/MainScriptTest.scala
@@ -94,4 +94,15 @@ class MainScriptTest extends AnyFunSuite {
     assert(mainScript.isEmpty)
     assert(additionalResources.length == 3)
   }
+
+  test("No resources") {
+    val resources = List.empty
+    val fun = Functionality("fun", resources = resources)
+
+    val mainScript = fun.mainScript
+    val additionalResources = fun.additionalResources
+
+    assert(mainScript.isEmpty)
+    assert(additionalResources.isEmpty)
+  }
 }

--- a/src/test/scala/io/viash/functionality/MainScriptTest.scala
+++ b/src/test/scala/io/viash/functionality/MainScriptTest.scala
@@ -1,0 +1,97 @@
+package io.viash.functionality
+
+import org.scalatest.funsuite.AnyFunSuite
+import io.viash.helpers.Logger
+import io.viash.functionality.resources.{BashScript, PlainFile}
+
+class MainScriptTest extends AnyFunSuite {
+  Logger.UseColorOverride.value = Some(false)
+
+  test("Single script") {
+    val resources = List(BashScript(path = Some("foo.sh")))
+    val fun = Functionality("fun", resources = resources)
+
+    val mainScript = fun.mainScript
+    val additionalResources = fun.additionalResources
+
+    assert(mainScript.isDefined)
+    assert(mainScript.get.path == Some("foo.sh"))
+    assert(additionalResources.isEmpty)
+  }
+
+  test("Multiple scripts") {
+    val resources = List(
+      BashScript(path = Some("foo.sh")),
+      BashScript(path = Some("bar.sh")),
+      BashScript(path = Some("baz.sh")),
+    )
+    val fun = Functionality("fun", resources = resources)
+
+    val mainScript = fun.mainScript
+    val additionalResources = fun.additionalResources
+
+    assert(mainScript.isDefined)
+    assert(mainScript.get.path == Some("foo.sh"))
+    assert(additionalResources.length == 2)
+  }
+
+  test("Single text file") {
+    val resources = List(PlainFile(path = Some("foo.txt")))
+    val fun = Functionality("fun", resources = resources)
+
+    val mainScript = fun.mainScript
+    val additionalResources = fun.additionalResources
+
+    assert(mainScript.isEmpty)
+    assert(additionalResources.length == 1)
+    assert(additionalResources.head.path == Some("foo.txt"))
+  }
+
+  test("Multiple text files") {
+    val resources = List(
+      PlainFile(path = Some("foo.txt")),
+      PlainFile(path = Some("bar.txt")),
+      PlainFile(path = Some("baz.txt")),
+    )
+    val fun = Functionality("fun", resources = resources)
+
+    val mainScript = fun.mainScript
+    val additionalResources = fun.additionalResources
+
+    assert(mainScript.isEmpty)
+    assert(additionalResources.length == 3)
+  }
+
+  test("Mixed Script and text files, first is script") {
+    val resources = List(
+      BashScript(path = Some("foo.sh")),
+      PlainFile(path = Some("bar.txt")),
+      BashScript(path = Some("baz.sh")),
+    )
+
+    val fun = Functionality("fun", resources = resources)
+
+    val mainScript = fun.mainScript
+    val additionalResources = fun.additionalResources
+
+    assert(mainScript.isDefined)
+    assert(mainScript.get.path == Some("foo.sh"))
+    assert(additionalResources.length == 2)
+  }
+
+  test("Mixed Script and text files, first is text file") {
+    val resources = List(
+      PlainFile(path = Some("foo.txt")),
+      BashScript(path = Some("bar.sh")),
+      PlainFile(path = Some("baz.txt")),
+    )
+
+    val fun = Functionality("fun", resources = resources)
+
+    val mainScript = fun.mainScript
+    val additionalResources = fun.additionalResources
+
+    assert(mainScript.isEmpty)
+    assert(additionalResources.length == 3)
+  }
+}


### PR DESCRIPTION
## Describe your changes

Fix an issue where if the first resource is not a script, the resource is silently dropped

## Related issue(s)

<!-- Replace xxxx with the GitHub issue number. -->

Closes #650 

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [ ] Minor change (non-breaking change which does not modify existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [x] I have performed a self-review of my code by checking the "Changed Files" tab.
- [x] My code follows the code style of this project.

Tests:

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

Documentation:

- [x] Proposed changes are described in the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.

## Test Environment

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test environment.
-->

