### PR TITLE
make `vsh` the default organization for `vsh` repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ TODO add summary
 
 * `resources_test`: This field is removed again from the `_viash.yaml` as it was decided to impliment this temporary functionality using the `info` field (PR #711).
 
+* `vsh organization`: ViashHub repositories now use `vsh` as the default organization (PR #718).
+  Instead of having to specify `repo: vsh/repo_name`, you can now just specify `repo: repo_name`, which is now also the prefered way.
+
 # Viash 0.9.0-RC4 (2024-05-29): Improvements for CI
 
 These are mainly improvements for issues highlighted by running Viash in a CI environment.

--- a/src/main/scala/io/viash/config/dependencies/ViashhubRepository.scala
+++ b/src/main/scala/io/viash/config/dependencies/ViashhubRepository.scala
@@ -25,14 +25,21 @@ import java.nio.file.Paths
 
 @description("A Viash-Hub repository where remote dependency components can be found.")
 @example(
-  """type: viashhub
+  """type: vsh
+    |repo: biobox
+    |tag: 0.1.0
+    |""".stripMargin,
+  "yaml"
+)
+@example(
+  """type: vsh
     |repo: openpipelines-bio/openpipeline
     |tag: 0.8.0
     |""".stripMargin,
   "yaml"
 )
 @example(
-  """type: viashhub
+  """type: vsh
     |repo: openpipelines-bio/openpipeline
     |tag: 0.7.1
     |path: src/test/resources/testns

--- a/src/main/scala/io/viash/config/dependencies/ViashhubRepositoryTrait.scala
+++ b/src/main/scala/io/viash/config/dependencies/ViashhubRepositoryTrait.scala
@@ -39,13 +39,18 @@ trait ViashhubRepositoryTrait extends AbstractGitRepository {
     }
   }
 
+  lazy val fullRepo = repo.contains("/") match {
+    case true => repo
+    case false => s"vsh/$repo"
+  }
+
   def getCacheIdentifier(): Option[String] =
-    Some(s"viashhub-${repo.replace("/", "-")}${tag.map(_.prepended('-')).getOrElse("")}")
+    Some(s"viashhub-${fullRepo.replace("/", "-")}${tag.map(_.prepended('-')).getOrElse("")}")
 
-  lazy val uri = s"https://viash-hub.com/$repo.git"
-  lazy val uri_ssh = s"git@viash-hub.com:$repo.git"
+  lazy val uri = s"https://viash-hub.com/$fullRepo.git"
+  lazy val uri_ssh = s"git@viash-hub.com:$fullRepo.git"
   val fakeCredentials = "nouser:nopass@" // obfuscate the credentials a bit so we don't trigger GitGuardian
-  lazy val uri_nouser = s"https://${fakeCredentials}viash-hub.com/$repo.git"
+  lazy val uri_nouser = s"https://${fakeCredentials}viash-hub.com/$fullRepo.git"
 
-  val storePath = repo // no need to add 'viash-hub.com' to the store path as 'type' (vsh) will be added
+  val storePath = fullRepo // no need to add 'viash-hub.com' to the store path as 'type' (vsh) will be added
 }

--- a/src/main/scala/io/viash/config/dependencies/ViashhubRepositoryWithName.scala
+++ b/src/main/scala/io/viash/config/dependencies/ViashhubRepositoryWithName.scala
@@ -25,8 +25,16 @@ import java.nio.file.Paths
 
 @description("A Viash-Hub repository where remote dependency components can be found.")
 @example(
+  """name: biobox
+    |type: vsh
+    |repo: biobox
+    |tag: 0.1.0
+    |""".stripMargin,
+  "yaml"
+)
+@example(
   """name: openpipeline
-    |type: viashhub
+    |type: vsh
     |repo: openpipelines-bio/openpipeline
     |tag: 0.8.0
     |""".stripMargin,
@@ -34,7 +42,7 @@ import java.nio.file.Paths
 )
 @example(
   """name: viash-testns
-    |type: viashhub
+    |type: vsh
     |repo: openpipelines-bio/openpipeline
     |tag: 0.7.1
     |path: src/test/resources/testns

--- a/src/test/scala/io/viash/config/dependencies/Repository.scala
+++ b/src/test/scala/io/viash/config/dependencies/Repository.scala
@@ -22,6 +22,7 @@ class RepositoryTest extends AnyFunSuite {
     val githubRepo = repo.get.asInstanceOf[GithubRepository]
     assert(githubRepo.repo == "viash-io/viash")
     assert(githubRepo.tag == Some("v2.0.0"))
+    assert(githubRepo.uri == "https://github.com/viash-io/viash.git")
   }
 
   test("Repository.unapply: handles viashhub syntax") {
@@ -31,6 +32,27 @@ class RepositoryTest extends AnyFunSuite {
     val viashhubRepo = repo.get.asInstanceOf[ViashhubRepository]
     assert(viashhubRepo.repo == "viash-io/viash")
     assert(viashhubRepo.tag == Some("v2.0.0"))
+    assert(viashhubRepo.uri == "https://viash-hub.com/viash-io/viash.git")
+  }
+
+  test("Repository.unapply: handles viashhub syntax with implicit vsh organization") {
+    val repo = Repository.unapply("vsh://viash@v2.0.0")
+    assert(repo.isDefined)
+    assert(repo.get.isInstanceOf[ViashhubRepository])
+    val viashhubRepo = repo.get.asInstanceOf[ViashhubRepository]
+    assert(viashhubRepo.repo == "viash")
+    assert(viashhubRepo.tag == Some("v2.0.0"))
+    assert(viashhubRepo.uri == "https://viash-hub.com/vsh/viash.git")
+  }
+
+  test("Repository.unapply: handles viashhub syntax with explicit vsh organization") {
+    val repo = Repository.unapply("vsh://vsh/viash@v2.0.0")
+    assert(repo.isDefined)
+    assert(repo.get.isInstanceOf[ViashhubRepository])
+    val viashhubRepo = repo.get.asInstanceOf[ViashhubRepository]
+    assert(viashhubRepo.repo == "vsh/viash")
+    assert(viashhubRepo.tag == Some("v2.0.0"))
+    assert(viashhubRepo.uri == "https://viash-hub.com/vsh/viash.git")
   }
 
   test("Repository.unapply: handles local syntax") {


### PR DESCRIPTION
## Describe your changes

if no `/` is found in the `repo`, add `vsh/` as `fullRepo`, which is used to create the uri fields.

## Related issue(s)

<!-- Replace xxxx with the GitHub issue number. -->

Closes #717

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [ ] Minor change (non-breaking change which does not modify existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [x] I have performed a self-review of my code by checking the "Changed Files" tab.
- [x] My code follows the code style of this project.

Tests:

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

Documentation:

- [x] Proposed changes are described in the CHANGELOG.md.
- [x] I have updated the documentation accordingly.

## Test Environment

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test environment.
-->

