### PR TITLE
Make viash automount prefix configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ TODO add summary
 
 ## MINOR CHANGES
 
-* `ExecutableRunner`: Add parameter `docker_automount_prefix` to allow for a custom prefix for automounted folders (PR #xxx).
+* `ExecutableRunner`: Add parameter `docker_automount_prefix` to allow for a custom prefix for automounted folders (PR #739).
 
 ## BUG FIXES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 TODO add summary
 
+## MINOR CHANGES
+
+* `ExecutableRunner`: Add parameter `docker_automount_prefix` to allow for a custom prefix for automounted folders (PR #xxx).
+
 ## BUG FIXES
 
 * `platforms`: Re-introduce the `--platform` and `--apply_platform` arguments to improve backwards compatibility (PR #725).

--- a/src/main/resources/io/viash/helpers/bashutils/ViashDockerAutodetectMount.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashDockerAutodetectMount.sh
@@ -1,7 +1,8 @@
 # ViashDockerAutodetectMount: auto configuring docker mounts from parameters
-# $1                  : The parameter value
-# returns             : New parameter
-# $VIASH_DIRECTORY_MOUNTS : Added another parameter to be passed to docker
+# $1                             : The parameter value
+# returns                        : New parameter
+# $VIASH_DIRECTORY_MOUNTS        : Added another parameter to be passed to docker
+# $VIASH_DOCKER_AUTOMOUNT_PREFIX : The prefix to be used for the automounts
 # examples:
 #   ViashDockerAutodetectMount /path/to/bar      # returns '/viash_automount/path/to/bar'
 #   ViashDockerAutodetectMountArg /path/to/bar   # returns '--volume="/path/to:/viash_automount/path/to"'
@@ -14,7 +15,7 @@ function ViashDockerAutodetectMount {
     mount_source=`dirname "$abs_path"`
     base_name=`basename "$abs_path"`
   fi
-  mount_target="/viash_automount$mount_source"
+  mount_target="$VIASH_DOCKER_AUTOMOUNT_PREFIX$mount_source"
   if [ -z "$base_name" ]; then
     echo "$mount_target"
   else
@@ -30,11 +31,11 @@ function ViashDockerAutodetectMountArg {
     mount_source=`dirname "$abs_path"`
     base_name=`basename "$abs_path"`
   fi
-  mount_target="/viash_automount$mount_source"
+  mount_target="$VIASH_DOCKER_AUTOMOUNT_PREFIX$mount_source"
   ViashDebug "ViashDockerAutodetectMountArg $1 -> $mount_source -> $mount_target"
   echo "--volume=\"$mount_source:$mount_target\""
 }
 function ViashDockerStripAutomount {
   abs_path=$(ViashAbsolutePath "$1")
-  echo "${abs_path#/viash_automount}"
+  echo "${abs_path#$VIASH_DOCKER_AUTOMOUNT_PREFIX}"
 }

--- a/src/main/scala/io/viash/runners/ExecutableRunner.scala
+++ b/src/main/scala/io/viash/runners/ExecutableRunner.scala
@@ -104,6 +104,7 @@ final case class ExecutableRunner(
   @description("The default prefix to use for automounting directories in Docker. This is used to mount directories from the host into the Docker container.")
   @example("docker_automount_prefix: /viash_automount", "yaml")
   @default("/viash_automount")
+  @since("since 0.9.0")
   docker_automount_prefix: String = "/viash_automount",
 
   `type`: String = "executable"

--- a/src/main/scala/io/viash/runners/ExecutableRunner.scala
+++ b/src/main/scala/io/viash/runners/ExecutableRunner.scala
@@ -104,7 +104,7 @@ final case class ExecutableRunner(
   @description("The default prefix to use for automounting directories in Docker. This is used to mount directories from the host into the Docker container.")
   @example("docker_automount_prefix: /viash_automount", "yaml")
   @default("/viash_automount")
-  @since("since 0.9.0")
+  @since("Viash 0.9.0")
   docker_automount_prefix: String = "/viash_automount",
 
   `type`: String = "executable"

--- a/src/main/scala/io/viash/runners/ExecutableRunner.scala
+++ b/src/main/scala/io/viash/runners/ExecutableRunner.scala
@@ -101,12 +101,6 @@ final case class ExecutableRunner(
   @default("Empty")
   docker_run_args: OneOrMore[String] = Nil,
 
-  @description("The default prefix to use for automounting directories in Docker. This is used to mount directories from the host into the Docker container.")
-  @example("docker_automount_prefix: /viash_automount", "yaml")
-  @default("/viash_automount")
-  @since("Viash 0.9.0")
-  docker_automount_prefix: String = "/viash_automount",
-
   `type`: String = "executable"
 ) extends Runner {
 
@@ -433,7 +427,7 @@ final case class ExecutableRunner(
          |
          |# configure default docker automount prefix if it is unset
          |if [ -z "$${VIASH_DOCKER_AUTOMOUNT_PREFIX+x}" ]; then
-         |  VIASH_DOCKER_AUTOMOUNT_PREFIX="${docker_automount_prefix}"
+         |  VIASH_DOCKER_AUTOMOUNT_PREFIX="/viash_automount"
          |fi""".stripMargin
     
     val preRun =

--- a/src/main/scala/io/viash/runners/ExecutableRunner.scala
+++ b/src/main/scala/io/viash/runners/ExecutableRunner.scala
@@ -101,6 +101,11 @@ final case class ExecutableRunner(
   @default("Empty")
   docker_run_args: OneOrMore[String] = Nil,
 
+  @description("The default prefix to use for automounting directories in Docker. This is used to mount directories from the host into the Docker container.")
+  @example("docker_automount_prefix: /viash_automount", "yaml")
+  @default("/viash_automount")
+  docker_automount_prefix: String = "/viash_automount",
+
   `type`: String = "executable"
 ) extends Runner {
 
@@ -290,7 +295,12 @@ final case class ExecutableRunner(
     }
     
     val preParse =
-      s"""${Bash.ViashDockerFuns}
+      s"""# configure default docker automount prefix if it is unset
+        |if [ -z "$${VIASH_DOCKER_AUTOMOUNT_PREFIX+x}" ]; then
+        |  VIASH_DOCKER_AUTOMOUNT_PREFIX="${docker_automount_prefix}"
+        |fi
+        |
+        |${Bash.ViashDockerFuns}
         |
         |# ViashDockerFile: print the dockerfile to stdout
         |# $$1    : engine identifier

--- a/src/main/scala/io/viash/runners/ExecutableRunner.scala
+++ b/src/main/scala/io/viash/runners/ExecutableRunner.scala
@@ -295,12 +295,7 @@ final case class ExecutableRunner(
     }
     
     val preParse =
-      s"""# configure default docker automount prefix if it is unset
-        |if [ -z "$${VIASH_DOCKER_AUTOMOUNT_PREFIX+x}" ]; then
-        |  VIASH_DOCKER_AUTOMOUNT_PREFIX="${docker_automount_prefix}"
-        |fi
-        |
-        |${Bash.ViashDockerFuns}
+      s"""${Bash.ViashDockerFuns}
         |
         |# ViashDockerFile: print the dockerfile to stdout
         |# $$1    : engine identifier
@@ -433,7 +428,12 @@ final case class ExecutableRunner(
          |${Bash.ViashAbsolutePath}
          |${Bash.ViashDockerAutodetectMount}
          |# initialise variables
-         |VIASH_DIRECTORY_MOUNTS=()""".stripMargin
+         |VIASH_DIRECTORY_MOUNTS=()
+         |
+         |# configure default docker automount prefix if it is unset
+         |if [ -z "$${VIASH_DOCKER_AUTOMOUNT_PREFIX+x}" ]; then
+         |  VIASH_DOCKER_AUTOMOUNT_PREFIX="${docker_automount_prefix}"
+         |fi""".stripMargin
     
     val preRun =
       f"""

--- a/src/test/scala/io/viash/e2e/build/DockerMoreSuite.scala
+++ b/src/test/scala/io/viash/e2e/build/DockerMoreSuite.scala
@@ -27,8 +27,6 @@ class DockerMoreSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   // check whether executable was created
   private val executable = Paths.get(tempFolStr, config.name).toFile
-  private val execPathInDocker = Paths.get("/viash_automount", executable.getPath).toFile.toString
-
 
   test("Prepare base config derivation and verify", DockerTest) {
     val newConfigFilePath = configDeriver.derive(

--- a/src/test/scala/io/viash/e2e/build/DockerSuite.scala
+++ b/src/test/scala/io/viash/e2e/build/DockerSuite.scala
@@ -162,8 +162,6 @@ class DockerSuite extends AnyFunSuite with BeforeAndAfterAll {
         Seq(
           executable.toString,
           executable.toString,
-          "--output", output.toString,
-          "--log", log.toString,
           "--real_number", "123.456",
           "--whole_number", "789",
           "-s", "my$weird#string"
@@ -178,8 +176,6 @@ class DockerSuite extends AnyFunSuite with BeforeAndAfterAll {
     assert(stdout.contains("""whole_number: |789|"""))
     assert(stdout.contains("""s: |my$weird#string|"""))
     assert(stdout.contains("""truth: |false|"""))
-    assert(stdout.contains(s"""output: |${output.getPath}|"""))
-    assert(stdout.contains(s"""log: |${log.getPath}|"""))
     assert(stdout.contains("""optional: ||"""))
     assert(stdout.contains("""optional_with_default: |The default value.|"""))
     assert(stdout.contains("""multiple: ||"""))
@@ -200,8 +196,6 @@ class DockerSuite extends AnyFunSuite with BeforeAndAfterAll {
         Seq(
           executable.toString,
           executable.toString,
-          "--output", output.toString,
-          "--log", log.toString,
           "--real_number", "123.456",
           "--whole_number", "789",
           "-s", "my$weird#string"
@@ -216,8 +210,6 @@ class DockerSuite extends AnyFunSuite with BeforeAndAfterAll {
     assert(stdout.contains("""whole_number: |789|"""))
     assert(stdout.contains("""s: |my$weird#string|"""))
     assert(stdout.contains("""truth: |false|"""))
-    assert(stdout.contains(s"""output: |/foobar${output.getPath}|"""))
-    assert(stdout.contains(s"""log: |/foobar${log.getPath}|"""))
     assert(stdout.contains("""optional: ||"""))
     assert(stdout.contains("""optional_with_default: |The default value.|"""))
     assert(stdout.contains("""multiple: ||"""))


### PR DESCRIPTION
## Describe your changes

### MINOR CHANGES

* `ExecutableRunner`: Add parameter `docker_automount_prefix` to allow for a custom prefix for automounted folders (PR #xxx).

## Related issue(s)

<!-- Replace xxxx with the GitHub issue number. -->

Closes #xxxx 

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [x] Minor change (non-breaking change which does not modify existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [x] I have performed a self-review of my code by checking the "Changed Files" tab.
- [x] My code follows the code style of this project.

Tests:

- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

Documentation:

- [x] Proposed changes are described in the CHANGELOG.md.
- [x] I have updated the documentation accordingly.

## Test Environment

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test environment.
-->

