### PR TITLE
Always use local variables when storing the options to prevent overri…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ TODO add summary
 
 * `viash ns exec`: Fix "relative fields" outputting absolute paths (PR# 737). Additionally, improve path resolution when using the `--src` argument.
 
+* `bashwrapper`: Fix an issue where running `viash test` which builds the test docker container would ignore test failures but subsequential runs would work correctly (PR #754).
+
 # Viash 0.9.0-RC6 (2024-06-17): Hotfix for docker image name generation
 
 Fix an issue where docker image names were not generated correctly.

--- a/src/main/resources/io/viash/helpers/bashutils/ViashAbsolutePath.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashAbsolutePath.sh
@@ -7,6 +7,9 @@
 #   ViashAbsolutePath /foo/bar/..     # returns /foo
 function ViashAbsolutePath {
   local thePath
+  local parr
+  local parr
+  local len
   if [[ ! "$1" =~ ^/ ]]; then
     thePath="$PWD/$1"
   else

--- a/src/main/resources/io/viash/helpers/bashutils/ViashAbsolutePath.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashAbsolutePath.sh
@@ -8,7 +8,7 @@
 function ViashAbsolutePath {
   local thePath
   local parr
-  local parr
+  local outp
   local len
   if [[ ! "$1" =~ ^/ ]]; then
     thePath="$PWD/$1"

--- a/src/main/resources/io/viash/helpers/bashutils/ViashDockerAutodetectMount.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashDockerAutodetectMount.sh
@@ -17,7 +17,7 @@ function ViashDockerAutodetectMount {
     mount_source=`dirname "$abs_path"`
     base_name=`basename "$abs_path"`
   fi
-  local  mount_target="$VIASH_DOCKER_AUTOMOUNT_PREFIX$mount_source"
+  local mount_target="$VIASH_DOCKER_AUTOMOUNT_PREFIX$mount_source"
   if [ -z "$base_name" ]; then
     echo "$mount_target"
   else

--- a/src/main/resources/io/viash/helpers/bashutils/ViashDockerAutodetectMount.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashDockerAutodetectMount.sh
@@ -6,7 +6,9 @@
 #   ViashDockerAutodetectMount /path/to/bar      # returns '/viash_automount/path/to/bar'
 #   ViashDockerAutodetectMountArg /path/to/bar   # returns '--volume="/path/to:/viash_automount/path/to"'
 function ViashDockerAutodetectMount {
-  abs_path=$(ViashAbsolutePath "$1")
+  local abs_path=$(ViashAbsolutePath "$1")
+  local mount_source
+  local base_name
   if [ -d "$abs_path" ]; then
     mount_source="$abs_path"
     base_name=""
@@ -14,7 +16,7 @@ function ViashDockerAutodetectMount {
     mount_source=`dirname "$abs_path"`
     base_name=`basename "$abs_path"`
   fi
-  mount_target="/viash_automount$mount_source"
+  local mount_target="/viash_automount$mount_source"
   if [ -z "$base_name" ]; then
     echo "$mount_target"
   else
@@ -22,7 +24,9 @@ function ViashDockerAutodetectMount {
   fi
 }
 function ViashDockerAutodetectMountArg {
-  abs_path=$(ViashAbsolutePath "$1")
+  local abs_path=$(ViashAbsolutePath "$1")
+  local mount_source
+  local base_name
   if [ -d "$abs_path" ]; then
     mount_source="$abs_path"
     base_name=""
@@ -30,11 +34,11 @@ function ViashDockerAutodetectMountArg {
     mount_source=`dirname "$abs_path"`
     base_name=`basename "$abs_path"`
   fi
-  mount_target="/viash_automount$mount_source"
+  local mount_target="/viash_automount$mount_source"
   ViashDebug "ViashDockerAutodetectMountArg $1 -> $mount_source -> $mount_target"
   echo "--volume=\"$mount_source:$mount_target\""
 }
 function ViashDockerStripAutomount {
-  abs_path=$(ViashAbsolutePath "$1")
+  local abs_path=$(ViashAbsolutePath "$1")
   echo "${abs_path#/viash_automount}"
 }

--- a/src/main/resources/io/viash/helpers/bashutils/ViashDockerFuns.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashDockerFuns.sh
@@ -13,7 +13,7 @@ function ViashDockerInstallationCheck {
   fi
 
   ViashDebug "Checking whether the Docker daemon is running"
-  save=$-; set +e
+  local save=$-; set +e
   docker_version=$(docker version --format '{{.Client.APIVersion}}' 2> /dev/null)
   out=$?
   [[ $save =~ e ]] && set -e
@@ -67,7 +67,7 @@ function ViashDockerPull {
   if [ $VIASH_VERBOSITY -ge $VIASH_LOGCODE_INFO ]; then
     docker pull $1 && return 0 || return 1
   else
-    save=$-; set +e
+    local save=$-; set +e
     docker pull $1 2> /dev/null > /dev/null
     out=$?
     [[ $save =~ e ]] && set -e
@@ -89,7 +89,7 @@ function ViashDockerPull {
 #   echo $?                                     # returns '1'
 function ViashDockerPush {
   ViashNotice "Pushing image to '$1'"
-  save=$-; set +e
+  local save=$-; set +e
   if [ $VIASH_VERBOSITY -ge $VIASH_LOGCODE_INFO ]; then
     docker push $1
     out=$?
@@ -113,7 +113,7 @@ function ViashDockerPush {
 # examples:
 #   ViashDockerPullElseBuild mynewcomponent
 function ViashDockerPullElseBuild {
-  save=$-; set +e
+  local save=$-; set +e
   ViashDockerPull $1
   out=$?
   [[ $save =~ e ]] && set -e

--- a/src/main/resources/io/viash/helpers/bashutils/ViashDockerFuns.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashDockerFuns.sh
@@ -15,7 +15,7 @@ function ViashDockerInstallationCheck {
   ViashDebug "Checking whether the Docker daemon is running"
   local save=$-; set +e
   docker_version=$(docker version --format '{{.Client.APIVersion}}' 2> /dev/null)
-  out=$?
+  local out=$?
   [[ $save =~ e ]] && set -e
   if [ $out -ne 0 ]; then
     ViashCritical "Docker daemon does not seem to be running. Try one of the following:"
@@ -69,7 +69,7 @@ function ViashDockerPull {
   else
     local save=$-; set +e
     docker pull $1 2> /dev/null > /dev/null
-    out=$?
+    local out=$?
     [[ $save =~ e ]] && set -e
     if [ $out -ne 0 ]; then
       ViashWarning "Could not pull from '$1'. Docker image doesn't exist or is not accessible."
@@ -90,6 +90,7 @@ function ViashDockerPull {
 function ViashDockerPush {
   ViashNotice "Pushing image to '$1'"
   local save=$-; set +e
+  local out
   if [ $VIASH_VERBOSITY -ge $VIASH_LOGCODE_INFO ]; then
     docker push $1
     out=$?
@@ -115,7 +116,7 @@ function ViashDockerPush {
 function ViashDockerPullElseBuild {
   local save=$-; set +e
   ViashDockerPull $1
-  out=$?
+  local out=$?
   [[ $save =~ e ]] && set -e
   if [ $out -ne 0 ]; then
     ViashDockerBuild $@

--- a/src/main/resources/io/viash/helpers/bashutils/ViashDockerFuns.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashDockerFuns.sh
@@ -14,7 +14,7 @@ function ViashDockerInstallationCheck {
 
   ViashDebug "Checking whether the Docker daemon is running"
   local save=$-; set +e
-  docker_version=$(docker version --format '{{.Client.APIVersion}}' 2> /dev/null)
+  local docker_version=$(docker version --format '{{.Client.APIVersion}}' 2> /dev/null)
   local out=$?
   [[ $save =~ e ]] && set -e
   if [ $out -ne 0 ]; then

--- a/src/main/resources/io/viash/helpers/bashutils/ViashFindTargetDir.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashFindTargetDir.sh
@@ -3,9 +3,9 @@
 # $1      : The location from where to start the upward search
 # returns : The absolute path of the '.build.yaml' file
 function ViashFindTargetDir {
-  SOURCE="$1"
-  while [[ "$SOURCE" != "" && ! -e "$SOURCE/.build.yaml" ]]; do
-    SOURCE=${SOURCE%/*}
+  local source="$1"
+  while [[ "$source" != "" && ! -e "$source/.build.yaml" ]]; do
+    source=${source%/*}
   done
-  echo $SOURCE
+  echo $source
 }

--- a/src/main/resources/io/viash/helpers/bashutils/ViashSourceDir.sh
+++ b/src/main/resources/io/viash/helpers/bashutils/ViashSourceDir.sh
@@ -3,11 +3,11 @@
 # $1      : Should always be set to ${BASH_SOURCE[0]}
 # returns : The absolute path of the bash file
 function ViashSourceDir {
-  SOURCE="$1"
-  while [ -h "$SOURCE" ]; do
-    DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
-    SOURCE="$(readlink "$SOURCE")"
-    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+  local source="$1"
+  while [ -h "$source" ]; do
+    local dir="$( cd -P "$( dirname "$source" )" >/dev/null 2>&1 && pwd )"
+    source="$(readlink "$source")"
+    [[ $source != /* ]] && source="$dir/$source"
   done
-  cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd
+  cd -P "$( dirname "$source" )" >/dev/null 2>&1 && pwd
 }

--- a/src/test/scala/io/viash/TestHelper.scala
+++ b/src/test/scala/io/viash/TestHelper.scala
@@ -8,6 +8,8 @@ import org.scalatest.Tag
 import java.nio.file.{Files, Path, Paths}
 import scala.reflect.ClassTag
 
+import io.viash.helpers.Exec
+
 object TestHelper {
 
   case class TestMainOutput(
@@ -89,4 +91,28 @@ object TestHelper {
     md5.digest.map("%02x".format(_)).mkString
   }
 
+  def checkDockerImageExists(name: String): Boolean = checkDockerImageExists(name, "latest")
+
+  def checkDockerImageExists(name: String, tag: String): Boolean = {
+    val out = Exec.runCatch(
+      Seq("docker", "images", name)
+    )
+
+    // print(out)
+    val regex = s"$name\\s*$tag".r
+
+    regex.findFirstIn(out.output).isDefined
+  }
+
+  def removeDockerImage(name: String): Unit = {
+    Exec.runCatch(
+      Seq("docker", "rmi", name, "-f")
+    )
+  }
+
+  def removeDockerImage(name: String, tag: String): Unit = {
+    Exec.runCatch(
+      Seq("docker", "rmi", s"$name:$tag", "-f")
+    )
+  }
 }

--- a/src/test/scala/io/viash/auxiliary/MainBuildAuxiliaryDockerRequirements.scala
+++ b/src/test/scala/io/viash/auxiliary/MainBuildAuxiliaryDockerRequirements.scala
@@ -31,31 +31,17 @@ abstract class AbstractMainBuildAuxiliaryDockerRequirements extends FixtureAnyFu
   // Fixture will remove the docker image before starting and remove it again after finishing
   def withFixture(test: OneArgTest) = {
     // remove docker if it exists
-    removeDockerImage(dockerTag)
-    assert(!checkDockerImageExists(dockerTag))
+    TestHelper.removeDockerImage(dockerTag)
+    assert(!TestHelper.checkDockerImageExists(dockerTag))
 
     val theFixture = FixtureParam()
 
     val outcome = withFixture(test.toNoArgTest(theFixture)) // "loan" the fixture to the test
 
     // Tests finished, remove docker image
-    removeDockerImage(dockerTag)
+    TestHelper.removeDockerImage(dockerTag)
 
     outcome
-  }
-
-  def checkDockerImageExists(name: String): Boolean = {
-    val out = Exec.runCatch(
-      Seq("docker", "images", name)
-    )
-    val regex = s"$name\\s*latest".r
-    regex.findFirstIn(out.output).isDefined
-  }
-
-  def removeDockerImage(name: String): Unit = {
-    Exec.runCatch(
-      Seq("docker", "rmi", name, "-f")
-    )
   }
 
   def deriveEngineConfig(setup: Option[String], test_setup: Option[String], name: String): String = {
@@ -90,7 +76,7 @@ class MainBuildAuxiliaryDockerRequirementsApk extends AbstractMainBuildAuxiliary
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -114,7 +100,7 @@ class MainBuildAuxiliaryDockerRequirementsApk extends AbstractMainBuildAuxiliary
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -138,7 +124,7 @@ class MainBuildAuxiliaryDockerRequirementsApk extends AbstractMainBuildAuxiliary
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -167,7 +153,7 @@ class MainBuildAuxiliaryDockerRequirementsApt extends AbstractMainBuildAuxiliary
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -191,7 +177,7 @@ class MainBuildAuxiliaryDockerRequirementsApt extends AbstractMainBuildAuxiliary
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -215,7 +201,7 @@ class MainBuildAuxiliaryDockerRequirementsApt extends AbstractMainBuildAuxiliary
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -244,7 +230,7 @@ class MainBuildAuxiliaryDockerRequirementsYum extends AbstractMainBuildAuxiliary
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -268,7 +254,7 @@ class MainBuildAuxiliaryDockerRequirementsYum extends AbstractMainBuildAuxiliary
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -292,7 +278,7 @@ class MainBuildAuxiliaryDockerRequirementsYum extends AbstractMainBuildAuxiliary
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -321,7 +307,7 @@ class MainBuildAuxiliaryDockerRequirementsRuby extends AbstractMainBuildAuxiliar
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -345,7 +331,7 @@ class MainBuildAuxiliaryDockerRequirementsRuby extends AbstractMainBuildAuxiliar
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -369,7 +355,7 @@ class MainBuildAuxiliaryDockerRequirementsRuby extends AbstractMainBuildAuxiliar
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -398,7 +384,7 @@ class MainBuildAuxiliaryDockerRequirementsR extends AbstractMainBuildAuxiliaryDo
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -422,7 +408,7 @@ class MainBuildAuxiliaryDockerRequirementsR extends AbstractMainBuildAuxiliaryDo
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -446,7 +432,7 @@ class MainBuildAuxiliaryDockerRequirementsR extends AbstractMainBuildAuxiliaryDo
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -488,7 +474,7 @@ class MainBuildAuxiliaryDockerRequirementsRBioc extends AbstractMainBuildAuxilia
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -512,7 +498,7 @@ class MainBuildAuxiliaryDockerRequirementsRBioc extends AbstractMainBuildAuxilia
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 
@@ -536,7 +522,7 @@ class MainBuildAuxiliaryDockerRequirementsRBioc extends AbstractMainBuildAuxilia
       newConfigFilePath
     )
 
-    assert(checkDockerImageExists(dockerTag))
+    assert(TestHelper.checkDockerImageExists(dockerTag))
     assert(executableRequirementsFile.exists)
     assert(executableRequirementsFile.canExecute)
 

--- a/src/test/scala/io/viash/e2e/build/DockerSetup.scala
+++ b/src/test/scala/io/viash/e2e/build/DockerSetup.scala
@@ -33,8 +33,8 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     val tag = "mytestbash"
     
     //remove docker if it exists
-    removeDockerImage(tag, "0.1-throwawayimage")
-    assert(!checkDockerImageExists(tag, "0.1-throwawayimage"))
+    TestHelper.removeDockerImage(tag, "0.1-throwawayimage")
+    assert(!TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
 
     // build viash wrapper without --setup
     TestHelper.testMain(
@@ -49,7 +49,7 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     assert(executable.canExecute)
 
     // verify docker still doesn't exist
-    assert(!checkDockerImageExists(tag, "0.1-throwawayimage"))
+    assert(!TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
 
     // run viash wrapper with ---setup
     val out = Exec.runCatch(
@@ -58,15 +58,15 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     assert(out.exitValue == 0)
 
     // verify docker now exists
-    assert(checkDockerImageExists(tag, "0.1-throwawayimage"))
+    assert(TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
   }
 
   test("viash with --setup creates docker during build", DockerTest) {
     val tag = "mytestbash"
 
     // remove docker if it exists
-    removeDockerImage(tag, "0.1-throwawayimage")
-    assert(!checkDockerImageExists(tag, "0.1-throwawayimage"))
+    TestHelper.removeDockerImage(tag, "0.1-throwawayimage")
+    assert(!TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
 
     // build viash wrapper with --setup
     TestHelper.testMain(
@@ -82,7 +82,7 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     assert(executable.canExecute)
 
     // verify docker exists
-    assert(checkDockerImageExists(tag, "0.1-throwawayimage"))
+    assert(TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
   }
 
   test("Get info of a docker image using docker inspect", DockerTest) {
@@ -182,8 +182,8 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     val tag = "myorg/mytestbash"
 
     // remove docker if it exists
-    removeDockerImage(tag, "0.1-throwawayimage")
-    assert(!checkDockerImageExists(tag, "0.1-throwawayimage"))
+    TestHelper.removeDockerImage(tag, "0.1-throwawayimage")
+    assert(!TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
 
     // build viash wrapper with --setup
     TestHelper.testMain(
@@ -199,7 +199,7 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     assert(executable.canExecute)
 
     // verify docker exists
-    assert(checkDockerImageExists(tag, "0.1-throwawayimage"))
+    assert(TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
   }
 
   test("Get info of a docker image with target_package set", DockerTest) {
@@ -207,8 +207,8 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     val tag = "pack/mytestbash"
 
     // remove docker if it exists
-    removeDockerImage(tag, "0.1-throwawayimage")
-    assert(!checkDockerImageExists(tag, "0.1-throwawayimage"))
+    TestHelper.removeDockerImage(tag, "0.1-throwawayimage")
+    assert(!TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
 
     // build viash wrapper with --setup
     TestHelper.testMain(
@@ -224,7 +224,7 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     assert(executable.canExecute)
 
     // verify docker exists
-    assert(checkDockerImageExists(tag, "0.1-throwawayimage"))
+    assert(TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
   }
 
   test("Get info of a docker image with target_organization and target_package set", DockerTest) {
@@ -237,8 +237,8 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     val tag = "myorg/pack/mytestbash"
 
     // remove docker if it exists
-    removeDockerImage(tag, "0.1-throwawayimage")
-    assert(!checkDockerImageExists(tag, "0.1-throwawayimage"))
+    TestHelper.removeDockerImage(tag, "0.1-throwawayimage")
+    assert(!TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
 
     // build viash wrapper with --setup
     TestHelper.testMain(
@@ -254,7 +254,7 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     assert(executable.canExecute)
 
     // verify docker exists
-    assert(checkDockerImageExists(tag, "0.1-throwawayimage"))
+    assert(TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
   }
 
   test("Get info of a docker image with organization and package name set in the package config", DockerTest) {
@@ -268,8 +268,8 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     Files.write(temporaryConfigFolder.resolve("_viash.yaml"), package_config.getBytes)
 
     // remove docker if it exists
-    removeDockerImage(tag, "0.1-throwawayimage")
-    assert(!checkDockerImageExists(tag, "0.1-throwawayimage"))
+    TestHelper.removeDockerImage(tag, "0.1-throwawayimage")
+    assert(!TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
 
     // build viash wrapper with --setup
     TestHelper.testMain(
@@ -286,32 +286,7 @@ class DockerSetup extends AnyFunSuite with BeforeAndAfterAll {
     assert(executable.canExecute)
 
     // verify docker exists
-    assert(checkDockerImageExists(tag, "0.1-throwawayimage"))
-  }
-
-  def checkDockerImageExists(name: String): Boolean = checkDockerImageExists(name, "latest")
-
-  def checkDockerImageExists(name: String, tag: String): Boolean = {
-    val out = Exec.runCatch(
-      Seq("docker", "images", name)
-    )
-
-    // print(out)
-    val regex = s"$name\\s*$tag".r
-
-    regex.findFirstIn(out.output).isDefined
-  }
-
-  def removeDockerImage(name: String): Unit = {
-    Exec.runCatch(
-      Seq("docker", "rmi", name, "-f")
-    )
-  }
-
-  def removeDockerImage(name: String, tag: String): Unit = {
-    Exec.runCatch(
-      Seq("docker", "rmi", s"$name:$tag", "-f")
-    )
+    assert(TestHelper.checkDockerImageExists(tag, "0.1-throwawayimage"))
   }
 
   override def afterAll(): Unit = {

--- a/src/test/scala/io/viash/e2e/run/MainRunDockerSuite.scala
+++ b/src/test/scala/io/viash/e2e/run/MainRunDockerSuite.scala
@@ -4,7 +4,7 @@ import io.viash._
 
 import java.nio.file.{Files, Paths, StandardCopyOption}
 
-import io.viash.helpers.{IO, Exec}
+import io.viash.helpers.IO
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -90,8 +90,8 @@ class MainRunDockerSuite extends AnyFunSuite with BeforeAndAfterAll {
     // This then results in the exit code not being returned correctly.
     val image_name = s"throwaway-image-${this.getClass.getName}".toLowerCase()
 
-    removeDockerImage(image_name)
-    assert(!checkDockerImageExists(image_name))
+    TestHelper.removeDockerImage(image_name)
+    assert(!TestHelper.checkDockerImageExists(image_name))
 
     val config = 
       s"""name: myscript
@@ -116,20 +116,6 @@ class MainRunDockerSuite extends AnyFunSuite with BeforeAndAfterAll {
 
     assert(testOutput.exitCode == Some(1))
     assert(testOutput.stdout.contains("foo\n"))
-  }
-
-  def checkDockerImageExists(name: String): Boolean = {
-    val out = Exec.runCatch(
-      Seq("docker", "images", name)
-    )
-    val regex = s"$name\\s*latest".r
-    regex.findFirstIn(out.output).isDefined
-  }
-
-  def removeDockerImage(name: String): Unit = {
-    Exec.runCatch(
-      Seq("docker", "rmi", name, "-f")
-    )
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
…ding in sub functions

## Describe your changes

Use `local` consistently when executing `save=$-; set +e` in the bash wrapper.
Essentially, the `-e` option wasn't being set again.

To give a more clear explanation of what's going on:
```
function foo2 {
	foo="foo2"
	echo "foo2: $foo"
}

function foo1 {
	local foo="foo1"
	foo2
	echo "foo1: $foo"
}

foo="foo"
foo1
echo "foo: $foo"
```

results in:
```
foo2: test2
foo1: test2
test: test
```

## Related issue(s)

Closes #753 

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [ ] Minor change (non-breaking change which does not modify existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [x] I have performed a self-review of my code by checking the "Changed Files" tab.
- [x] My code follows the code style of this project.

Tests:

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

Documentation:

- [x] Proposed changes are described in the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.

## Test Environment

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test environment.
-->

