### PR TITLE
escaping parameters in nextflow wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,19 @@ TODO add summary
 
 * `scala`: Update Scala to 2.13.14 (PR #764).
 
+* `NextflowEngine`: Also parse `${id}` and `${key}` aside from `$id` and `$key` as identifier placeholders for filenames (PR #756).
+
+## BUG FIXES
+
+* `NextflowEngine`: Fix escaping of odd filename containing special characters (PR #756). Filenames containing a `$` character caused Bash to try to interpret it as a variable.
+
 # Viash 0.9.0-RC7 (2024-08-13): General bugfixes and improvements
 
 These are bug fixes and other improvements that solve some edge case issues and improve the overall user experience and usability of Viash.
 
 ## BREAKING CHANGES
 
-* `NextflowPlatform`: Swap the order of execution of `runIf` and `filter` when calling `.run()`. This means that `runIf` is now executed before `filter` (PR #660).
+* `NextflowEngine`: Swap the order of execution of `runIf` and `filter` when calling `.run()`. This means that `runIf` is now executed before `filter` (PR #660).
 
 ## NEW FUNCTIONALITY
 
@@ -22,7 +28,7 @@ These are bug fixes and other improvements that solve some edge case issues and 
 
 * `config schema`: Add `label` & `summary` fields for Config, PackageConfig, argument groups, and all argument types (PR #743).
 
-* `NextflowPlatform`: Added `runIf` functionality to `runEach` (PR #660).
+* `NextflowEngine`: Added `runIf` functionality to `runEach` (PR #660).
 
 ## MINOR CHANGES
 

--- a/src/main/resources/io/viash/runners/nextflow/VDSL3Helper.nf
+++ b/src/main/resources/io/viash/runners/nextflow/VDSL3Helper.nf
@@ -202,7 +202,7 @@ def _vdsl3ProcessFactory(Map workflowArgs, Map meta, String rawScript) {
   def createParentStr = meta.config.allArguments
     .findAll { it.type == "file" && it.direction == "output" && it.create_parent }
     .collect { par -> 
-      "\${ args.containsKey(\"${par.plainName}\") ? \"mkdir_parent \\\"\" + (args[\"${par.plainName}\"] instanceof String ? args[\"${par.plainName}\"] : args[\"${par.plainName}\"].join('\" \"')).replace(\"\\\$\", \"\\\\\\\$\") + \"\\\"\" : \"\" }"
+      "\${ args.containsKey(\"${par.plainName}\") ? \"mkdir_parent '\" + (args[\"${par.plainName}\"] instanceof String ? args[\"${par.plainName}\"] : args[\"${par.plainName}\"].join('\" \"')).replace(\"'\", \"'\\\"'\\\"'\") + \"'\" : \"\" }"
     }
     .join("\n")
 
@@ -211,7 +211,7 @@ def _vdsl3ProcessFactory(Map workflowArgs, Map meta, String rawScript) {
     .findAll { it.type == "file" && it.direction.toLowerCase() == "input" }
     .collect { par ->
       def viash_par_contents = "(viash_par_${par.plainName} instanceof List ? viash_par_${par.plainName}.join(\"${par.multiple_sep}\") : viash_par_${par.plainName})"
-      "\n\${viash_par_${par.plainName}.empty ? \"\" : \"export VIASH_PAR_${par.plainName.toUpperCase()}=\\\"\" + ${viash_par_contents} + \"\\\"\"}"
+      "\n\${viash_par_${par.plainName}.empty ? \"\" : \"export VIASH_PAR_${par.plainName.toUpperCase()}='\" + ${viash_par_contents}.toString().replaceAll(\"'\", \"'\\\"'\\\"'\") + \"'\"}"
     }
 
   // NOTE: if using docker, use /tmp instead of tmpDir!
@@ -259,10 +259,10 @@ def _vdsl3ProcessFactory(Map workflowArgs, Map meta, String rawScript) {
   |$stub
   |\"\"\"
   |script:$assertStr
-  |def escapeText = { s -> s.toString().replaceAll('([`"\$])', '\\\\\\\\\$1') }
+  |def escapeText = { s -> s.toString().replaceAll("'", "'\\\"'\\\"'") }
   |def parInject = args
   |  .findAll{key, value -> value != null}
-  |  .collect{key, value -> "export VIASH_PAR_\${key.toUpperCase()}=\\\"\${escapeText(value)}\\\""}
+  |  .collect{key, value -> "export VIASH_PAR_\${key.toUpperCase()}='\${escapeText(value)}'"}
   |  .join("\\n")
   |\"\"\"
   |# meta exports

--- a/src/main/resources/io/viash/runners/nextflow/VDSL3Helper.nf
+++ b/src/main/resources/io/viash/runners/nextflow/VDSL3Helper.nf
@@ -202,7 +202,7 @@ def _vdsl3ProcessFactory(Map workflowArgs, Map meta, String rawScript) {
   def createParentStr = meta.config.allArguments
     .findAll { it.type == "file" && it.direction == "output" && it.create_parent }
     .collect { par -> 
-      "\${ args.containsKey(\"${par.plainName}\") ? \"mkdir_parent \\\"\" + (args[\"${par.plainName}\"] instanceof String ? args[\"${par.plainName}\"] : args[\"${par.plainName}\"].join('\" \"')) + \"\\\"\" : \"\" }"
+      "\${ args.containsKey(\"${par.plainName}\") ? \"mkdir_parent \\\"\" + (args[\"${par.plainName}\"] instanceof String ? args[\"${par.plainName}\"] : args[\"${par.plainName}\"].join('\" \"')).replace(\"\\\$\", \"\\\\\\\$\") + \"\\\"\" : \"\" }"
     }
     .join("\n")
 
@@ -259,7 +259,7 @@ def _vdsl3ProcessFactory(Map workflowArgs, Map meta, String rawScript) {
   |$stub
   |\"\"\"
   |script:$assertStr
-  |def escapeText = { s -> s.toString().replaceAll('([`"])', '\\\\\\\\\$1') }
+  |def escapeText = { s -> s.toString().replaceAll('([`"\$])', '\\\\\\\\\$1') }
   |def parInject = args
   |  .findAll{key, value -> value != null}
   |  .collect{key, value -> "export VIASH_PAR_\${key.toUpperCase()}=\\\"\${escapeText(value)}\\\""}

--- a/src/main/resources/io/viash/runners/nextflow/VDSL3Helper.nf
+++ b/src/main/resources/io/viash/runners/nextflow/VDSL3Helper.nf
@@ -71,7 +71,11 @@ def vdsl3WorkflowFactory(Map args, Map meta, String rawScript) {
               val = val.join(par.multiple_sep)
             }
             if (par.direction == "output" && par.type == "file") {
-              val = val.replaceAll('\\$id', id).replaceAll('\\$key', key)
+              val = val
+                .replaceAll('\\$id', id)
+                .replaceAll('\\$\\{id\\}', id)
+                .replaceAll('\\$key', key)
+                .replaceAll('\\$\\{key\\}', key)
             }
             [parName, val]
           }

--- a/src/main/resources/io/viash/runners/nextflow/states/publishStates.nf
+++ b/src/main/resources/io/viash/runners/nextflow/states/publishStates.nf
@@ -59,7 +59,9 @@ def publishStates(Map args) {
 
           def yamlFilename = yamlTemplate_
             .replaceAll('\\$id', id_)
+            .replaceAll('\\$\\{id\\}', id_)
             .replaceAll('\\$key', key_)
+            .replaceAll('\\$\\{key\\}', key_)
 
             // TODO: do the pathnames in state_ match up with the outputFilenames_?
 
@@ -130,7 +132,9 @@ def publishStatesByConfig(Map args) {
           def yamlTemplate = params.containsKey("output_state") ? params.output_state : '$id.$key.state.yaml'
           def yamlFilename = yamlTemplate
             .replaceAll('\\$id', id_)
+            .replaceAll('\\$\\{id\\}', id_)
             .replaceAll('\\$key', key_)
+            .replaceAll('\\$\\{key\\}', key_)
           def yamlDir = java.nio.file.Paths.get(yamlFilename).getParent()
 
           // the processed state is a list of [key, value, inputPath, outputFilename] tuples, where
@@ -172,7 +176,9 @@ def publishStatesByConfig(Map args) {
                 // instantiate the template
                 def filename = filenameTemplate
                   .replaceAll('\\$id', id_)
+                  .replaceAll('\\$\\{id\\}', id_)
                   .replaceAll('\\$key', key_)
+                  .replaceAll('\\$\\{key\\}', key_)
                 if (par.multiple) {
                   // if the parameter is multiple: true, the filename
                   // should contain a wildcard '*' that is replaced with

--- a/src/test/scala/io/viash/runners/nextflow/Vdsl3StandaloneTest.scala
+++ b/src/test/scala/io/viash/runners/nextflow/Vdsl3StandaloneTest.scala
@@ -94,6 +94,37 @@ class Vdsl3StandaloneTest extends AnyFunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("With output id and key keywords", NextflowTest) {
+    val (exitCode, stdOut, stdErr) = NextflowTestHelper.run(
+      mainScript = "target/nextflow/step2/main.nf",
+      args = List(
+        "--id", "foo",
+        "--input1", "resources/lines3.txt",
+        "--input2", "resources/lines5.txt",
+        "--output1", "$id.${id}.$key.${key}.txt",
+        // "--output2", "$foo$bar.txt", // can't do this (yet) because of Nextflow doesn't support '$' yet.
+        "--publish_dir", "moduleOutput2"
+      ),
+      cwd = tempFolFile
+    )
+
+    assert(exitCode == 0, s"\nexit code was $exitCode\nStd output:\n$stdOut\nStd error:\n$stdErr")
+    assert(Files.exists(Paths.get(tempFolStr + "/moduleOutput2/foo.foo.step2.step2.txt")))
+    // assert(Files.exists(Paths.get(tempFolStr + "/moduleOutput2/$foo$bar.txt")))
+    
+    val src1 = Source.fromFile(tempFolStr + "/moduleOutput2/foo.foo.step2.step2.txt")
+    // val src2 = Source.fromFile(tempFolStr + "/moduleOutput2/$foo$bar.txt")
+    try {
+      val moduleOut1 = src1.getLines().mkString(",")
+      // val moduleOut2 = src2.getLines().mkString(",")
+      assert(moduleOut1.equals("one,two,three"))
+      // assert(moduleOut2.equals("1,2,3,4,5"))
+    } finally {
+      src1.close()
+      // src2.close()
+    }
+  }
+
   test("With yamlblob param_list", NextflowTest) {
     val paramListStr = "[{input1: resources/lines3.txt, input2: resources/lines5.txt}]"
     val (exitCode, stdOut, stdErr) = NextflowTestHelper.run(


### PR DESCRIPTION
only fixes/tested `${id}` as an output file parameter
as input file parameter it's broken in a different way

## Describe your changes

<!-- 
Please include a summary of the change and which issue is fixed.
-->

## Related issue(s)

<!-- Replace xxxx with the GitHub issue number. -->

Closes #698  

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [x] Minor change (non-breaking change which does not modify existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [x] I have performed a self-review of my code by checking the "Changed Files" tab.
- [x] My code follows the code style of this project.

Tests:

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

Documentation:

- [x] Proposed changes are described in the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.

## Test Environment

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test environment.
-->

