### PR TITLE
Automatically convert integers to doubles when argument type is `double`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## BUG FIXES
 
-* `NextflowRunner`: Automatically convert integers to doubles when argument type is `double` (PR #xxx).
+* `NextflowRunner`: Automatically convert integers to doubles when argument type is `double` (PR #823).
 
 # Viash 0.8.7 (2025-04-01): Backport support upcoming version of Nextflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Viash 0.8.8 (xxxx-xx-xx): xxxx
+
+## BUG FIXES
+
+* `NextflowRunner`: Automatically convert integers to doubles when argument type is `double` (PR #xxx).
+
 # Viash 0.8.7 (2025-04-01): Backport support upcoming version of Nextflow
 
 The upcoming release of Nextflow introduces a new class for loading scripts and renamed the old class.

--- a/src/main/resources/io/viash/platforms/nextflow/arguments/_checkArgumentType.nf
+++ b/src/main/resources/io/viash/platforms/nextflow/arguments/_checkArgumentType.nf
@@ -66,64 +66,56 @@ def _checkArgumentType(String stage, Map par, Object value, String errorIdentifi
       foundClass = "List[${e.foundClass}]"
     }
   } else if (par.type == "string") {
-    // cast to string if need be
+    // cast to string if need be. only cast if the value is a GString
     if (value instanceof GString) {
-      value = value.toString()
+      value = value as String
     }
     expectedClass = value instanceof String ? null : "String"
   } else if (par.type == "integer") {
     // cast to integer if need be
-    if (value instanceof String) {
+    if (value !instanceof Integer) {
       try {
-        value = value.toInteger()
+        value = value as Integer
       } catch (NumberFormatException e) {
-        // do nothing
+        expectedClass = "Integer"
       }
     }
-    if (value instanceof java.math.BigInteger) {
-      value = value.intValue()
-    }
-    expectedClass = value instanceof Integer ? null : "Integer"
   } else if (par.type == "long") {
     // cast to long if need be
-    if (value instanceof String) {
+    if (value !instanceof Long) {
       try {
-        value = value.toLong()
+        value = value as Long
       } catch (NumberFormatException e) {
-        // do nothing
+        expectedClass = "Long"
       }
     }
-    if (value instanceof Integer) {
-      value = value.toLong()
-    }
-    expectedClass = value instanceof Long ? null : "Long"
   } else if (par.type == "double") {
     // cast to double if need be
-    if (value instanceof String) {
+    if (value !instanceof Double) {
       try {
-        value = value.toDouble()
+        value = value as Double
       } catch (NumberFormatException e) {
-        // do nothing
+        expectedClass = "Double"
       }
     }
-    if (value instanceof java.math.BigDecimal || value instanceof java.math.BigInteger) {
-      value = value.doubleValue()
+  } else if (par.type == "float") {
+    // cast to float if need be
+    if (value !instanceof Float) {
+      try {
+        value = value as Float
+      } catch (NumberFormatException e) {
+        expectedClass = "Float"
+      }
     }
-    if (value instanceof Float || value instanceof Integer || value instanceof Long) {
-      value = value.toDouble()
-    }
-    expectedClass = value instanceof Double ? null : "Double"
   } else if (par.type == "boolean" | par.type == "boolean_true" | par.type == "boolean_false") {
     // cast to boolean if need be
-    if (value instanceof String) {
-      def valueLower = value.toLowerCase()
-      if (valueLower == "true") {
-        value = true
-      } else if (valueLower == "false") {
-        value = false
+    if (value !instanceof Boolean) {
+      try {
+        value = value as Boolean
+      } catch (Exception e) {
+        expectedClass = "Boolean"
       }
     }
-    expectedClass = value instanceof Boolean ? null : "Boolean"
   } else if (par.type == "file" && (par.direction == "input" || stage == "output")) {
     // cast to path if need be
     if (value instanceof String) {
@@ -135,10 +127,13 @@ def _checkArgumentType(String stage, Map par, Object value, String errorIdentifi
     expectedClass = value instanceof Path ? null : "Path"
   } else if (par.type == "file" && stage == "input" && par.direction == "output") {
     // cast to string if need be
-    if (value instanceof GString) {
-      value = value.toString()
+    if (value !instanceof String) {
+      try {
+        value = value as String
+      } catch (Exception e) {
+        expectedClass = "String"
+      }
     }
-    expectedClass = value instanceof String ? null : "String"
   } else {
     // didn't find a match for par.type
     expectedClass = par.type

--- a/src/main/resources/io/viash/platforms/nextflow/arguments/_checkArgumentType.nf
+++ b/src/main/resources/io/viash/platforms/nextflow/arguments/_checkArgumentType.nf
@@ -106,10 +106,10 @@ def _checkArgumentType(String stage, Map par, Object value, String errorIdentifi
         // do nothing
       }
     }
-    if (value instanceof java.math.BigDecimal) {
+    if (value instanceof java.math.BigDecimal || value instanceof java.math.BigInteger) {
       value = value.doubleValue()
     }
-    if (value instanceof Float) {
+    if (value instanceof Float || value instanceof Integer || value instanceof Long) {
       value = value.toDouble()
     }
     expectedClass = value instanceof Double ? null : "Double"

--- a/src/test/resources/testnextflowvdsl3/src/integer_as_double/config.vsh.yaml
+++ b/src/test/resources/testnextflowvdsl3/src/integer_as_double/config.vsh.yaml
@@ -1,0 +1,25 @@
+functionality:
+  name: integer_as_double
+  arguments:
+    - name: "--input"
+      type: file
+      required: true
+      example: input.txt
+    - name: "--output"
+      type: file
+      required: true
+      direction: output
+      example: output.txt
+    - name: "--double"
+      type: double
+      required: true
+      direction: input
+      example: 10.5
+  resources:
+    - type: bash_script
+      path: script.sh
+platforms:
+  - type: native
+  - type: docker
+    image: nextflow/bash:latest
+  - type: nextflow

--- a/src/test/resources/testnextflowvdsl3/src/integer_as_double/script.sh
+++ b/src/test/resources/testnextflowvdsl3/src/integer_as_double/script.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+## VIASH START
+par_input='resources/lines3.txt'
+par_double='10.5'
+par_output='output.txt'
+## VIASH END
+
+echo "Copying $par_input to $par_output"
+cp "$par_input" "$par_output"
+
+echo "Adding $par_double to $par_output"
+echo "Double: $par_double" >> "$par_output"
+
+exit 0

--- a/src/test/scala/io/viash/platforms/nextflow/Vdsl3StandaloneTest.scala
+++ b/src/test/scala/io/viash/platforms/nextflow/Vdsl3StandaloneTest.scala
@@ -211,6 +211,41 @@ class Vdsl3StandaloneTest extends AnyFunSuite with BeforeAndAfterAll {
     }
   }
 
+
+  test("Whether integers can be converted to doubles", NextflowTest) {
+    val (exitCode, stdOut, stdErr) = NextflowTestHelper.run(
+      mainScript = "target/nextflow/integer_as_double/main.nf",
+      args = List(
+        "--id", "foo",
+        "--input", "resources/lines3.txt",
+        "--double", "10", // this should be an integer
+        "--publish_dir", "integerAsDouble"
+      ),
+      cwd = tempFolFile
+    )
+
+    assert(exitCode == 0, s"\nexit code was $exitCode\nStd output:\n$stdOut\nStd error:\n$stdErr")
+
+    val expectedFiles =
+      Map(
+        "state" -> "state.yaml",
+        "output" -> "output.txt", 
+      ).map{ case (id, suffix) =>
+        val path = temporaryFolder.resolve("integerAsDouble/foo.integer_as_double." + suffix)
+        (id, path)
+      }
+
+    // check if files exist
+    
+    val src = Source.fromFile(tempFolStr + "/integerAsDouble/foo.integer_as_double.output.txt")
+    try {
+      val moduleOut = src.getLines().mkString(",")
+      assert(moduleOut.equals("one,two,three,Double: 10.0"), s"Expected output 'one,two,three,10.0' but got '$moduleOut'")
+    } finally {
+      src.close()
+    }
+  }
+
   override def afterAll(): Unit = {
     IO.deleteRecursively(temporaryFolder)
   }

--- a/src/test/scala/io/viash/platforms/nextflow/Vdsl3StandaloneTest.scala
+++ b/src/test/scala/io/viash/platforms/nextflow/Vdsl3StandaloneTest.scala
@@ -213,14 +213,19 @@ class Vdsl3StandaloneTest extends AnyFunSuite with BeforeAndAfterAll {
 
 
   test("Whether integers can be converted to doubles", NextflowTest) {
+    // create params.yaml file
+    val paramsPath = temporaryFolder.resolve("params.yaml")
+    val paramsStr = """id: foo
+      |input: resources/lines3.txt
+      |double: 10
+      |publish_dir: integerAsDouble
+      |""".stripMargin
+    Files.write(paramsPath, paramsStr.getBytes(StandardCharsets.UTF_8))
+
     val (exitCode, stdOut, stdErr) = NextflowTestHelper.run(
       mainScript = "target/nextflow/integer_as_double/main.nf",
-      args = List(
-        "--id", "foo",
-        "--input", "resources/lines3.txt",
-        "--double", "10", // this should be an integer
-        "--publish_dir", "integerAsDouble"
-      ),
+      args = Nil,
+      paramsFile = Some(paramsPath.toString()),
       cwd = tempFolFile
     )
 


### PR DESCRIPTION
## Describe your changes

This PR allows users to pass an integer to a double argument without Nextflow throwing an error about it being the wrong type.

This fix needs to be ported to Viash 0.9 and dev as well.

<!-- 
Please include a summary of the change and which issue is fixed.
-->

## Related issue(s)

<!-- Replace xxxx with the GitHub issue number. -->

Closes #xxxx 

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [ ] Minor change (non-breaking change which does not modify existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [x] I have performed a self-review of my code by checking the "Changed Files" tab.
- [x] My code follows the code style of this project.

Tests:

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

Documentation:

- [x] Proposed changes are described in the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.

## Test Environment

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test environment.
-->

