### PR TITLE
Testing - Nextflow runner (edge): don't use ANSI logging

### DIFF
--- a/CHANGELOGS/CHANGELOG_0.10.md
+++ b/CHANGELOGS/CHANGELOG_0.10.md
@@ -36,7 +36,7 @@ TODO add summary
   * Backslash-quote sequences (`\'`) no longer break Python syntax
   * Dollar signs, newlines, and other special characters are properly preserved
 
-* `testBenches`: set `-ansi-log false` when running Nextflow in order to test against all captured sequential output (PR #886).
+* `testBenches`: set `-ansi-log false` when running Nextflow in order to test against all captured sequential output (PR #911).
 
 ## MINOR FIXES
 

--- a/CHANGELOGS/CHANGELOG_0.10.md
+++ b/CHANGELOGS/CHANGELOG_0.10.md
@@ -36,6 +36,8 @@ TODO add summary
   * Backslash-quote sequences (`\'`) no longer break Python syntax
   * Dollar signs, newlines, and other special characters are properly preserved
 
+* `testBenches`: set `-ansi-log false` when running Nextflow in order to test against all captured sequential output (PR #886).
+
 ## MINOR FIXES
 
 * `Executable`: Add more info to the --help (PR #802).

--- a/src/test/scala/io/viash/runners/nextflow/NextflowTestHelper.scala
+++ b/src/test/scala/io/viash/runners/nextflow/NextflowTestHelper.scala
@@ -144,6 +144,7 @@ object NextflowTestHelper {
       "nextflow" :: 
         { if (quiet) List("-q") else Nil } ::: 
         "run" :: "." ::
+        "-ansi-log" :: "false" ::
         "-main-script" :: mainScript ::
         { if (entry.isDefined) List("-entry", entry.get) else Nil } :::
         { if (paramsFile.isDefined) List("-params-file", paramsFile.get) else Nil } :::


### PR DESCRIPTION
## Describe your changes

Nextflow runner tests: do not use ANSI logging. This fixes issues with parsing the output from nextflow in several tests on the latest edge release.

## Related issue(s)

<!-- Replace xxxx with the GitHub issue number. -->

Closes #xxxx 

## Type of Change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New functionality (non-breaking change which adds functionality)
- [ ] Major change (non-breaking change which modifies existing functionality)
- [ ] Minor change (non-breaking change which does not modify existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

Requirements:

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc.
- [x] I have performed a self-review of my code by checking the "Changed Files" tab.
- [x] My code follows the code style of this project.

Tests:

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

Documentation:

- [x] Proposed changes are described in the CHANGELOG.md.
- [ ] I have updated the documentation accordingly.

## Test Environment

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test environment.
-->

